### PR TITLE
fix: SQL arguments in excess of what is required for matcher

### DIFF
--- a/quasar/services/registry/core.py
+++ b/quasar/services/registry/core.py
@@ -415,8 +415,7 @@ class Registry(DatabaseHandler, APIHandler):
                         match.asset_id,
                         match.primary_id,
                         match.confidence,
-                        match.match_type,
-                        match.identity_symbol
+                        match.match_type
                     )
                     if result:
                         stats['identified'] += 1


### PR DESCRIPTION
Fixes regression introduced by d77dd605  - where an additional SQL argument was added to a query for the matcher:
```python
result = await conn.fetchval(
    update_query,
    match.asset_id,        # $1
    match.primary_id,      # $2
    match.confidence,      # $3
    match.match_type,      # $4
    match.identity_symbol  # $5 - EXTRA!
)
```

This PR removes `match.identity_symbol` which was an erroneous addition from that commit.

Closes #47