### PR TITLE
Hide refresh button for UserIndex entries in registry view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# byte-code & build junk
+__pycache__/
+*.py[cod]
+*.so
+build/
+dist/
+*.egg-info/
+.coverage
+htmlcov/
+
+# editor / IDE folders
+tmpclaude-*
+nul
+.vscode/
+.cursor/
+.idea/
+.playwright-mcp/
+
+# development related research
+docs/throwaway/
+
+# local config & secrets
+.secrets/
+.env
+*.sqlite
+
+# tests, notebooks, auto-generated API docs
+scripts_local/
+*.ipynb
+docs/api/
+
+# version control
+.git

--- a/web/src/views/registry/ClassSummaryCard.js
+++ b/web/src/views/registry/ClassSummaryCard.js
@@ -139,21 +139,23 @@ const ClassSummaryCard = ({ class_summary, displayToast, onAssetsRefreshed }) =>
 
           {/* Card Icon - Right Justified */}
           <div className="d-flex align-items-center">
-              <CButton
-                  variant="ghost"
-                  color="body"
-                  size="sm"
-                  onClick={handleRefresh}
-                  disabled={isRefreshing}
-                  className="p-1 me-2"
-                  title="Refresh Assets"
-              >
-                  {isRefreshing ? (
-                      <CSpinner size="sm" component="span" aria-hidden="true" color="success" title="Refreshing..."/>
-                  ) : (
-                      <CIcon icon={cilSync} className="sm" />
-                  )}
-              </CButton>
+              {class_summary.class_subtype !== 'UserIndex' && (
+                <CButton
+                    variant="ghost"
+                    color="body"
+                    size="sm"
+                    onClick={handleRefresh}
+                    disabled={isRefreshing}
+                    className="p-1 me-2"
+                    title="Refresh Assets"
+                >
+                    {isRefreshing ? (
+                        <CSpinner size="sm" component="span" aria-hidden="true" color="success" title="Refreshing..."/>
+                    ) : (
+                        <CIcon icon={cilSync} className="sm" />
+                    )}
+                </CButton>
+              )}
               <CButton
                 variant="ghost"
                 color="body"


### PR DESCRIPTION
Fixes #57

UserIndex entries have manually managed members and don't support refresh from external providers. This hides the refresh button for these entries in the registry view.