### PR TITLE
Deprecate CryptoCalendar in favor of None exchange handling

### DIFF
--- a/.claude/docs/architectural_patterns.md
+++ b/.claude/docs/architectural_patterns.md
@@ -95,11 +95,11 @@ Function-level async timeout enforcement:
 
 ## Trading Calendar Abstraction
 
-Pluggable calendars for different asset classes:
+Pluggable calendars for different asset classes. Assets without an exchange (e.g., crypto)
+default to "always open" behavior:
 
-- `CryptoCalendar` (24/7): `quasar/lib/common/calendar.py:33-67`
-- `ForexCalendar` (24/5): `quasar/lib/common/calendar.py:70-119`
-- Registration: `quasar/lib/common/calendar.py:122-126`
+- `ForexCalendar` (24/5): `quasar/lib/common/calendar.py:21-79`
+- Registration: `quasar/lib/common/calendar.py:81-85`
 
 ## Matcher & Mapper Pattern
 

--- a/quasar/lib/common/calendar.py
+++ b/quasar/lib/common/calendar.py
@@ -1,8 +1,8 @@
-"""Trading calendar utility wrapping exchange_calendars with custom support for Crypto and Forex.
+"""Trading calendar utility wrapping exchange_calendars with custom Forex support.
 
 This module provides a unified interface for checking market status across various
-exchanges and asset classes, including standard stock exchanges, cryptocurrencies,
-and forex markets.
+exchanges and asset classes. Assets without an exchange (e.g., cryptocurrencies)
+default to 'always open' behavior.
 """
 
 import logging
@@ -17,63 +17,6 @@ from exchange_calendars import ExchangeCalendar, register_calendar_type
 logger = logging.getLogger(__name__)
 
 # --- Custom Calendar Definitions ---
-
-class CryptoCalendar(ExchangeCalendar):
-    """24/7 Trading Calendar for Cryptocurrencies."""
-
-    @property
-    def name(self) -> str:
-        """Return the calendar name.
-
-        Returns:
-            str: The calendar name ("CRYPTO").
-        """
-        return "CRYPTO"
-
-    @property
-    def tz(self):
-        """Return the timezone for the calendar.
-
-        Returns:
-            datetime.tzinfo: The UTC timezone.
-        """
-        return pytz.utc
-
-    @property
-    def open_times(self):
-        """Return the daily open times.
-
-        Returns:
-            tuple: Tuple containing the open time (00:00).
-        """
-        return ((None, time(0, 0)),)
-
-    @property
-    def close_times(self):
-        """Return the daily close times.
-
-        Returns:
-            tuple: Tuple containing the close time (23:59).
-        """
-        return ((None, time(23, 59)),)
-
-    @property
-    def regular_holidays(self):
-        """Return the list of regular holidays.
-
-        Returns:
-            None: Crypto markets have no holidays.
-        """
-        return None
-
-    @property
-    def weekmask(self) -> str:
-        """Return the weekmask defining active days (all 7 days).
-
-        Returns:
-            str: The weekmask "1111111".
-        """
-        return "1111111"
 
 class ForexCalendar(ExchangeCalendar):
     """24/5 Trading Calendar for Forex (Standard Sunday 5pm ET to Friday 5pm ET)."""
@@ -137,10 +80,9 @@ class ForexCalendar(ExchangeCalendar):
 
 # Register custom calendars with the library
 try:
-    register_calendar_type("CRYPTO", CryptoCalendar, force=True)
     register_calendar_type("XFX", ForexCalendar, force=True)
 except Exception as e:
-    logger.warning(f"Failed to register custom calendars: {e}")
+    logger.warning(f"Failed to register custom calendar: {e}")
 
 
 # --- TradingCalendar Wrapper ---

--- a/quasar/lib/providers/devtools/stubs.py
+++ b/quasar/lib/providers/devtools/stubs.py
@@ -71,7 +71,7 @@ class LiveStub(LiveDataProvider):
                 "symbol": "BTC-USD.STUB",
                 "matcher_symbol": "BTC-USD",
                 "name": "Bitcoin Stub",
-                "exchange": "CRYPTO",
+                "exchange": None,
                 "asset_class": "crypto",
                 "base_currency": "BTC",
                 "quote_currency": "USD",

--- a/tests/lib/common/test_calendar.py
+++ b/tests/lib/common/test_calendar.py
@@ -5,17 +5,6 @@ import pandas as pd
 import pytz
 from quasar.lib.common.calendar import TradingCalendar
 
-def test_is_open_now_crypto():
-    """Verify that CRYPTO is always open."""
-    assert TradingCalendar.is_open_now("CRYPTO") is True
-
-def test_is_session_crypto():
-    """Verify that CRYPTO has a session every day."""
-    # A weekend
-    assert TradingCalendar.is_session("CRYPTO", date(2025, 12, 20)) is True
-    # A holiday
-    assert TradingCalendar.is_session("CRYPTO", date(2025, 12, 25)) is True
-
 def test_is_session_nyse_holiday():
     """Verify that NYSE correctly identifies holidays."""
     # Christmas 2025 (Thursday)

--- a/tests/services/datahub/test_calendar_behavior.py
+++ b/tests/services/datahub/test_calendar_behavior.py
@@ -106,14 +106,14 @@ async def test_live_gatekeeper_filters_closed_markets(mock_calendar, datahub_wit
     # Add the mock provider to the hub
     hub._providers["MockLive"] = mock_live_provider
 
-    # Mock: AAPL (XNAS) is closed, BTC (CRYPTO) is open
+    # Mock: AAPL (XNAS) is closed, BTC (no exchange) is open
     def mock_is_open(mic):
-        return mic == "CRYPTO"
+        return mic is None
     mock_calendar.is_open_now.side_effect = mock_is_open
 
     # Symbols and MICs
     symbols = ["AAPL", "BTC/USD"]
-    exchanges = ["XNAS", "CRYPTO"]
+    exchanges = ["XNAS", None]
 
     # Mock _insert_bars to do nothing
     with patch.object(hub, '_insert_bars', new_callable=AsyncMock):

--- a/tests/services/datahub/test_handlers_collection.py
+++ b/tests/services/datahub/test_handlers_collection.py
@@ -345,7 +345,7 @@ class TestGetData:
         hub._providers["TestLiveProvider"] = mock_provider_live
 
         with patch.object(hub, '_insert_bars', new_callable=AsyncMock):
-            await hub.get_data("TestLiveProvider", "1h", ["TEST"], ["CRYPTO"])
+            await hub.get_data("TestLiveProvider", "1h", ["TEST"], [None])
 
             hub._insert_bars.assert_called()
 


### PR DESCRIPTION
## Summary
- Remove `CryptoCalendar` class and its registration from `calendar.py`
- Update `LiveStub` to return `exchange=None` for crypto assets (matching real provider behavior)
- Remove crypto-specific calendar tests that are now obsolete
- Update test data to use `None` instead of `"CRYPTO"` for exchange values
- Update `architectural_patterns.md` documentation

## Context

Crypto providers now return `None` for the exchange field. The `TradingCalendar` wrapper already returns `True` (always open) when `mic` is `None`, making the explicit `CryptoCalendar` class redundant dead code.

**Note:** PR #74 was created in error from a stale branch that included unrelated commits from the already-merged configurable-providers feature. This PR rectifies that by cherry-picking only the deprecation commit onto a clean base.

## Test plan
- [x] All 523 tests pass
- [x] No warnings about missing CRYPTO calendar
- [x] Verified crypto assets will use "always open" behavior via `mic=None` path

Closes #40
Supersedes #74