### PR TITLE
feat: Asset Re-mapping - Regenerate mappings after config changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,3 +118,10 @@ Check these files when working on specific areas:
 | Lib common utilities | `docs/reference/lib-common.md` |
 | Docstring conventions | `docs/contributing/docstrings.md` |
 | Git workflow | `docs/git-workflow.md` |
+
+## Active Technologies
+- Python 3.12 (backend), JavaScript/React 18 (frontend) + FastAPI, asyncpg, Pydantic (backend); CoreUI Pro, Redux (frontend) (001-asset-remap)
+- PostgreSQL 17 with TimescaleDB; existing `asset_mapping`, `common_symbols`, `index_memberships` tables (001-asset-remap)
+
+## Recent Changes
+- 001-asset-remap: Added Python 3.12 (backend), JavaScript/React 18 (frontend) + FastAPI, asyncpg, Pydantic (backend); CoreUI Pro, Redux (frontend)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "cryptography==45.0.2",
     "fastapi>=0.115.0",
     "lxml>=5.0.0",
-    "pandas>=2.0.0",
+    "pandas>=2.0.0,<3.0.0",
     "python-multipart>=0.0.9",
     "PyYAML>=6.0",
     "Requests==2.32.3",

--- a/quasar/lib/common/calendar.py
+++ b/quasar/lib/common/calendar.py
@@ -8,8 +8,8 @@ default to 'always open' behavior.
 import logging
 from datetime import datetime, date, time, timezone
 from typing import Optional, Dict
+from zoneinfo import ZoneInfo
 
-import pytz
 import pandas as pd
 import exchange_calendars as xcals
 from exchange_calendars import ExchangeCalendar, register_calendar_type
@@ -37,7 +37,7 @@ class ForexCalendar(ExchangeCalendar):
         Returns:
             datetime.tzinfo: The America/New_York timezone.
         """
-        return pytz.timezone("America/New_York")
+        return ZoneInfo("America/New_York")
 
     @property
     def open_times(self):

--- a/quasar/services/registry/core.py
+++ b/quasar/services/registry/core.py
@@ -50,7 +50,7 @@ from quasar.services.registry.schemas import (
     FileUploadResponse, UpdateAssetsResponse, DeleteClassResponse,
     AssetResponse, AssetMappingCreateResponse, AssetMappingPaginatedResponse,
     AssetMappingResponse, SuggestionsResponse,
-    AssetMappingRemapPreview,
+    AssetMappingRemapPreview, AssetMappingRemapResponse,
     ProviderPreferencesResponse, AvailableQuoteCurrenciesResponse,
     SecretKeysResponse, SecretsUpdateResponse,
     CommonSymbolResponse, CommonSymbolRenameResponse,
@@ -216,6 +216,12 @@ class Registry(
             self.handle_remap_preview,
             methods=['GET'],
             response_model=AssetMappingRemapPreview
+        )
+        self._api_app.router.add_api_route(
+            '/api/registry/asset-mappings/re-map',
+            self.handle_remap_assets,
+            methods=['POST'],
+            response_model=AssetMappingRemapResponse
         )
 
         # Common Symbols Routes (public API)

--- a/quasar/services/registry/core.py
+++ b/quasar/services/registry/core.py
@@ -198,12 +198,6 @@ class Registry(
             status_code=204
         )
         self._api_app.router.add_api_route(
-            '/api/registry/asset-mappings/{common_symbol}',
-            self.handle_get_asset_mappings_for_symbol,
-            methods=['GET'],
-            response_model=List[AssetMappingResponse]
-        )
-        self._api_app.router.add_api_route(
             '/api/registry/asset-mappings/common-symbol/{symbol}/rename',
             self.handle_rename_common_symbol,
             methods=['PUT'],
@@ -231,6 +225,15 @@ class Registry(
             self.handle_get_common_symbols,
             methods=['GET'],
             response_model=CommonSymbolResponse
+        )
+
+        # Dynamic route MUST come after static routes to avoid capturing static paths
+        # e.g., "common-symbols" would match {common_symbol} if registered first
+        self._api_app.router.add_api_route(
+            '/api/registry/asset-mappings/{common_symbol}',
+            self.handle_get_asset_mappings_for_symbol,
+            methods=['GET'],
+            response_model=List[AssetMappingResponse]
         )
 
         # Asset Mapping Suggestions (public API)

--- a/quasar/services/registry/core.py
+++ b/quasar/services/registry/core.py
@@ -50,6 +50,7 @@ from quasar.services.registry.schemas import (
     FileUploadResponse, UpdateAssetsResponse, DeleteClassResponse,
     AssetResponse, AssetMappingCreateResponse, AssetMappingPaginatedResponse,
     AssetMappingResponse, SuggestionsResponse,
+    AssetMappingRemapPreview,
     ProviderPreferencesResponse, AvailableQuoteCurrenciesResponse,
     SecretKeysResponse, SecretsUpdateResponse,
     CommonSymbolResponse, CommonSymbolRenameResponse,
@@ -207,6 +208,14 @@ class Registry(
             self.handle_rename_common_symbol,
             methods=['PUT'],
             response_model=CommonSymbolRenameResponse
+        )
+
+        # Asset Re-mapping Routes (public API)
+        self._api_app.router.add_api_route(
+            '/api/registry/asset-mappings/re-map/preview',
+            self.handle_remap_preview,
+            methods=['GET'],
+            response_model=AssetMappingRemapPreview
         )
 
         # Common Symbols Routes (public API)

--- a/quasar/services/registry/handlers/mappings.py
+++ b/quasar/services/registry/handlers/mappings.py
@@ -1245,8 +1245,11 @@ class MappingHandlersMixin(HandlerMixin):
         """Delete and regenerate asset mappings matching the specified filters.
 
         This operation is atomic: either all changes succeed or the entire
-        operation is rolled back. Uses REPEATABLE READ isolation to prevent
-        phantom reads during the delete-regenerate cycle.
+        operation is rolled back. Uses REPEATABLE READ isolation to ensure
+        a consistent snapshot during the delete-regenerate cycle.
+
+        Note: affected_indices is determined before deletion for reporting
+        purposes and reflects the state at query time.
 
         Args:
             request: Filter parameters specifying which mappings to re-map.

--- a/quasar/services/registry/schemas.py
+++ b/quasar/services/registry/schemas.py
@@ -554,3 +554,74 @@ class IndexHistoryChange(BaseModel):
 class IndexHistoryResponse(BaseModel):
     """Response model for GET /api/registry/indices/{name}/history endpoint."""
     changes: List[IndexHistoryChange]
+
+
+# =============================================================================
+# Asset Re-Mapping Schemas
+# =============================================================================
+
+class AssetMappingRemapRequest(BaseModel):
+    """Request model for POST /api/registry/asset-mappings/re-map endpoint.
+
+    Filter parameters for the re-map operation. At least one filter should be
+    specified to avoid re-mapping all mappings.
+    """
+    class_name: Optional[str] = Field(
+        default=None,
+        description="Provider name to filter by. If omitted, all providers are included."
+    )
+    class_type: Optional[ClassType] = Field(
+        default=None,
+        description="Required when class_name is specified."
+    )
+    asset_class: Optional[str] = Field(
+        default=None,
+        description="Asset class to filter by. If omitted, all asset classes are included."
+    )
+
+
+class AssetMappingRemapPreview(BaseModel):
+    """Response model for GET /api/registry/asset-mappings/re-map/preview endpoint.
+
+    Preview of the impact of a re-map operation.
+    """
+    mappings_to_delete: int = Field(
+        ..., description="Number of mappings that will be deleted."
+    )
+    providers_affected: List[str] = Field(
+        ..., description="List of provider names whose mappings will be re-generated."
+    )
+    affected_indices: List[str] = Field(
+        ..., description="Names of user indices that may lose members due to common_symbol deletion."
+    )
+    filter_applied: Dict[str, Any] = Field(
+        ..., description="Echo of the filter parameters that were applied."
+    )
+
+
+class AssetMappingRemapResponse(BaseModel):
+    """Response model for POST /api/registry/asset-mappings/re-map endpoint.
+
+    Result of the re-map operation.
+    """
+    status: Literal["success", "no_mappings"] = Field(
+        ..., description="Outcome of the operation."
+    )
+    deleted_mappings: int = Field(
+        ..., description="Number of mappings that were deleted."
+    )
+    created_mappings: int = Field(
+        ..., description="Number of new mappings that were created."
+    )
+    skipped_mappings: int = Field(
+        ..., description="Number of mappings that already existed (edge case after delete)."
+    )
+    failed_mappings: int = Field(
+        ..., description="Number of mappings that failed to create."
+    )
+    providers_affected: List[str] = Field(
+        ..., description="List of providers that were re-mapped."
+    )
+    affected_indices: List[str] = Field(
+        ..., description="User indices that lost members due to common_symbol deletion."
+    )

--- a/tests/lib/common/test_calendar.py
+++ b/tests/lib/common/test_calendar.py
@@ -2,7 +2,6 @@
 import pytest
 from datetime import date, datetime, time, timezone
 import pandas as pd
-import pytz
 from quasar.lib.common.calendar import TradingCalendar
 
 def test_is_session_nyse_holiday():

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -45,6 +45,7 @@
         "autoprefixer": "^10.4.19",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
+        "eslint-config-react-app": "^7.0.1",
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -69,12 +70,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
+      "integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -83,9 +84,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.2.tgz",
-      "integrity": "sha512-TUtMJYRPyUb/9aU8f3K0mjmjf6M9N5Woshn2CS6nqJSeJtTtQcpLUXjGt9vbF8ZGff0El99sWkLgzwW3VXnxZQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.6.tgz",
+      "integrity": "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -123,30 +124,72 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/generator": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.1.tgz",
-      "integrity": "sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==",
+    "node_modules/@babel/eslint-parser": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.28.6.tgz",
+      "integrity": "sha512-QGmsKi2PBO/MHSQk+AAgA9R6OHQr+VqnniFE0eMWZcVcfBZoA2dKn2hUsl3Csg/Plt9opRUWdY7//VXsrIlEiA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.1",
-        "@babel/types": "^7.27.1",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0",
+        "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@babel/eslint-parser/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
+      "integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
+        "@babel/types": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
@@ -156,28 +199,170 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
+      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/traverse": "^7.28.6",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-regexp-features-plugin": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
+      "integrity": "sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "regexpu-core": "^6.3.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-define-polyfill-provider": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz",
+      "integrity": "sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "debug": "^4.4.1",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.22.10"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/helper-define-polyfill-provider/node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.5",
+        "@babel/types": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.1.tgz",
-      "integrity": "sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-remap-async-to-generator": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
+      "integrity": "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-wrap-function": "^7.27.1",
         "@babel/traverse": "^7.27.1"
       },
       "engines": {
@@ -187,12 +372,34 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -207,9 +414,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -221,6 +428,21 @@
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-wrap-function": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz",
+      "integrity": "sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -240,18 +462,1127 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.2.tgz",
-      "integrity": "sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
+      "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.1"
+        "@babel/types": "^7.28.6"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.28.5.tgz",
+      "integrity": "sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
+      "integrity": "sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
+      "integrity": "sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
+      "integrity": "sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-transform-optional-chaining": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.13.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.6.tgz",
+      "integrity": "sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-class-properties": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
+      "integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-decorators": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.28.6.tgz",
+      "integrity": "sha512-RVdFPPyY9fCRAX68haPmOk2iyKW8PKJFthmm8NeSI3paNxKWGZIn99+VbIf0FrtCpFnPgnpF/L48tadi617ULg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/plugin-syntax-decorators": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.18.6.tgz",
+      "integrity": "sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.18.6",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-numeric-separator": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.18.6.tgz",
+      "integrity": "sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.18.6",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-optional-chaining": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.21.0.tgz",
+      "integrity": "sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-private-methods": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.18.6.tgz",
+      "integrity": "sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-decorators": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.28.6.tgz",
+      "integrity": "sha512-71EYI0ONURHJBL4rSFXnITXqXrrY8q4P0q006DPfN+Rk+ASM+++IBXem/ruokgBZR8YNEWZ8R6B+rCb8VcUTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-flow": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.28.6.tgz",
+      "integrity": "sha512-D+OrJumc9McXNEBI/JmFnc/0uCM2/Y3PEBG3gfV3QIYkKv5pvnpzFrl1kYCrcHJP8nOeFB/SHi1IHz29pNGuew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-assertions": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.28.6.tgz",
+      "integrity": "sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
+      "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-arrow-functions": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
+      "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-async-generator-functions": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.6.tgz",
+      "integrity": "sha512-9knsChgsMzBV5Yh3kkhrZNxH3oCYAfMBkNNaVN4cP2RVlFPe8wYdwwcnOsAbkdDoV9UjFtOXWrWB52M8W4jNeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-remap-async-to-generator": "^7.27.1",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-async-to-generator": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
+      "integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-remap-async-to-generator": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
+      "integrity": "sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoping": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz",
+      "integrity": "sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-properties": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz",
+      "integrity": "sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-static-block": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.6.tgz",
+      "integrity": "sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-classes": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz",
+      "integrity": "sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-replace-supers": "^7.28.6",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-computed-properties": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz",
+      "integrity": "sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/template": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-destructuring": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz",
+      "integrity": "sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-dotall-regex": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.28.6.tgz",
+      "integrity": "sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-duplicate-keys": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
+      "integrity": "sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.28.6.tgz",
+      "integrity": "sha512-5suVoXjC14lUN6ZL9OLKIHCNVWCrqGqlmEp/ixdXjvgnEl/kauLvvMO/Xw9NyMc95Joj1AeLVPVMvibBgSoFlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-dynamic-import": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
+      "integrity": "sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-explicit-resource-management": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.6.tgz",
+      "integrity": "sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/plugin-transform-destructuring": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.6.tgz",
+      "integrity": "sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-export-namespace-from": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
+      "integrity": "sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-flow-strip-types": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.27.1.tgz",
+      "integrity": "sha512-G5eDKsu50udECw7DL2AcsysXiQyB7Nfg521t2OAJ4tbfTJ27doHLeF/vlI1NZGlLdbb/v+ibvtL1YBQqYOwJGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/plugin-syntax-flow": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-for-of": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
+      "integrity": "sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-function-name": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
+      "integrity": "sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-json-strings": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.28.6.tgz",
+      "integrity": "sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-literals": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
+      "integrity": "sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-logical-assignment-operators": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.6.tgz",
+      "integrity": "sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-member-expression-literals": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
+      "integrity": "sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-amd": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
+      "integrity": "sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
+      "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-systemjs": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.28.5.tgz",
+      "integrity": "sha512-vn5Jma98LCOeBy/KpeQhXcV2WZgaRUtjwQmjoBuLNlOmkg0fB5pdvYVeWRYI69wWKwK2cD1QbMiUQnoujWvrew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-umd": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
+      "integrity": "sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.27.1.tgz",
+      "integrity": "sha512-SstR5JYy8ddZvD6MhV0tM/j16Qds4mIpJTOd1Yu9J9pJjH93bxHECF7pgtc28XvkzTD6Pxcm/0Z73Hvk7kb3Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-new-target": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
+      "integrity": "sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz",
+      "integrity": "sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-numeric-separator": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.28.6.tgz",
+      "integrity": "sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-rest-spread": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.6.tgz",
+      "integrity": "sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/plugin-transform-destructuring": "^7.28.5",
+        "@babel/plugin-transform-parameters": "^7.27.7",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-super": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
+      "integrity": "sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-catch-binding": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz",
+      "integrity": "sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-chaining": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz",
+      "integrity": "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-parameters": {
+      "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
+      "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-methods": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
+      "integrity": "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-property-in-object": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz",
+      "integrity": "sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-property-literals": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
+      "integrity": "sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-display-name": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.28.0.tgz",
+      "integrity": "sha512-D6Eujc2zMxKjfa4Zxl4GHMsmhKKZ9VpcqIchJLvwTxad9zWIYulwYItBovpDOoNLISpcZSXoDJ5gaGbQUDqViA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.28.6.tgz",
+      "integrity": "sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/plugin-syntax-jsx": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-development": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.27.1.tgz",
+      "integrity": "sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
@@ -286,6 +1617,415 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-react-pure-annotations": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.27.1.tgz",
+      "integrity": "sha512-JfuinvDOsD9FVMTHpzA/pBLisxpv1aSf+OIV8lgH3MuWrks19R27e6a6DipIg4aX1Zm9Wpb04p8wljfKrVSnPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-regenerator": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.6.tgz",
+      "integrity": "sha512-eZhoEZHYQLL5uc1gS5e9/oTknS0sSSAtd5TkKMUp3J+S/CaUjagc0kOUPsEbDmMeva0nC3WWl4SxVY6+OBuxfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-regexp-modifiers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.28.6.tgz",
+      "integrity": "sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-reserved-words": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
+      "integrity": "sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.5.tgz",
+      "integrity": "sha512-20NUVgOrinudkIBzQ2bNxP08YpKprUkRTiRSd2/Z5GOdPImJGkoN4Z7IQe1T5AdyKI1i5L6RBmluqdSzvaq9/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "babel-plugin-polyfill-corejs2": "^0.4.14",
+        "babel-plugin-polyfill-corejs3": "^0.13.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.5",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-shorthand-properties": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
+      "integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-spread": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz",
+      "integrity": "sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-sticky-regex": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
+      "integrity": "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-template-literals": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
+      "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typeof-symbol": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
+      "integrity": "sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
+      "integrity": "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-escapes": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
+      "integrity": "sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-property-regex": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.28.6.tgz",
+      "integrity": "sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-regex": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
+      "integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-sets-regex": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.28.6.tgz",
+      "integrity": "sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/preset-env": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.6.tgz",
+      "integrity": "sha512-GaTI4nXDrs7l0qaJ6Rg06dtOXTBCG6TMDB44zbqofCIC4PqC7SEvmFFtpxzCDw9W5aJ7RKVshgXTLvLdBFV/qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
+        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
+        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+        "@babel/plugin-syntax-import-assertions": "^7.28.6",
+        "@babel/plugin-syntax-import-attributes": "^7.28.6",
+        "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
+        "@babel/plugin-transform-arrow-functions": "^7.27.1",
+        "@babel/plugin-transform-async-generator-functions": "^7.28.6",
+        "@babel/plugin-transform-async-to-generator": "^7.28.6",
+        "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
+        "@babel/plugin-transform-block-scoping": "^7.28.6",
+        "@babel/plugin-transform-class-properties": "^7.28.6",
+        "@babel/plugin-transform-class-static-block": "^7.28.6",
+        "@babel/plugin-transform-classes": "^7.28.6",
+        "@babel/plugin-transform-computed-properties": "^7.28.6",
+        "@babel/plugin-transform-destructuring": "^7.28.5",
+        "@babel/plugin-transform-dotall-regex": "^7.28.6",
+        "@babel/plugin-transform-duplicate-keys": "^7.27.1",
+        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.28.6",
+        "@babel/plugin-transform-dynamic-import": "^7.27.1",
+        "@babel/plugin-transform-explicit-resource-management": "^7.28.6",
+        "@babel/plugin-transform-exponentiation-operator": "^7.28.6",
+        "@babel/plugin-transform-export-namespace-from": "^7.27.1",
+        "@babel/plugin-transform-for-of": "^7.27.1",
+        "@babel/plugin-transform-function-name": "^7.27.1",
+        "@babel/plugin-transform-json-strings": "^7.28.6",
+        "@babel/plugin-transform-literals": "^7.27.1",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.28.6",
+        "@babel/plugin-transform-member-expression-literals": "^7.27.1",
+        "@babel/plugin-transform-modules-amd": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.28.6",
+        "@babel/plugin-transform-modules-systemjs": "^7.28.5",
+        "@babel/plugin-transform-modules-umd": "^7.27.1",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.27.1",
+        "@babel/plugin-transform-new-target": "^7.27.1",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6",
+        "@babel/plugin-transform-numeric-separator": "^7.28.6",
+        "@babel/plugin-transform-object-rest-spread": "^7.28.6",
+        "@babel/plugin-transform-object-super": "^7.27.1",
+        "@babel/plugin-transform-optional-catch-binding": "^7.28.6",
+        "@babel/plugin-transform-optional-chaining": "^7.28.6",
+        "@babel/plugin-transform-parameters": "^7.27.7",
+        "@babel/plugin-transform-private-methods": "^7.28.6",
+        "@babel/plugin-transform-private-property-in-object": "^7.28.6",
+        "@babel/plugin-transform-property-literals": "^7.27.1",
+        "@babel/plugin-transform-regenerator": "^7.28.6",
+        "@babel/plugin-transform-regexp-modifiers": "^7.28.6",
+        "@babel/plugin-transform-reserved-words": "^7.27.1",
+        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
+        "@babel/plugin-transform-spread": "^7.28.6",
+        "@babel/plugin-transform-sticky-regex": "^7.27.1",
+        "@babel/plugin-transform-template-literals": "^7.27.1",
+        "@babel/plugin-transform-typeof-symbol": "^7.27.1",
+        "@babel/plugin-transform-unicode-escapes": "^7.27.1",
+        "@babel/plugin-transform-unicode-property-regex": "^7.28.6",
+        "@babel/plugin-transform-unicode-regex": "^7.27.1",
+        "@babel/plugin-transform-unicode-sets-regex": "^7.28.6",
+        "@babel/preset-modules": "0.1.6-no-external-plugins",
+        "babel-plugin-polyfill-corejs2": "^0.4.14",
+        "babel-plugin-polyfill-corejs3": "^0.13.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.5",
+        "core-js-compat": "^3.43.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-modules": {
+      "version": "0.1.6-no-external-plugins",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
+      "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/preset-react": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.28.5.tgz",
+      "integrity": "sha512-Z3J8vhRq7CeLjdC58jLv4lnZ5RKFUJWqH5emvxmv9Hv3BD1T9R/Im713R4MTKwvFaV74ejZ3sM01LyEKk4ugNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-transform-react-display-name": "^7.28.0",
+        "@babel/plugin-transform-react-jsx": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-development": "^7.27.1",
+        "@babel/plugin-transform-react-pure-annotations": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
+      "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
@@ -296,45 +2036,45 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.1.tgz",
-      "integrity": "sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
+      "integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.1",
-        "@babel/parser": "^7.27.1",
-        "@babel/template": "^7.27.1",
-        "@babel/types": "^7.27.1",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/generator": "^7.28.6",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.6",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6",
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
-      "integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
+      "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1153,32 +2893,19 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1191,9 +2918,9 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1205,6 +2932,40 @@
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
+    },
+    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
+      "version": "5.1.1-v1",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
+      "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-scope": "5.1.1"
+      }
+    },
+    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1896,6 +3657,20 @@
         "win32"
       ]
     },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rushstack/eslint-patch": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.15.0.tgz",
+      "integrity": "sha512-ojSshQPKwVvSMR8yT2L/QtUkV5SXi/IfDiJ4/8d6UbTPjiHVmxZzUAzGD8Tzks1b9+qQkZa0isUOvYObedITaw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1954,6 +3729,20 @@
       "integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -1979,11 +3768,297 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
+      "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/type-utils": "5.62.0",
+        "@typescript-eslint/utils": "5.62.0",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.62.0.tgz",
+      "integrity": "sha512-RTXpeB3eMkpoclG3ZHft6vG/Z30azNHuqY6wKPBHlVMZFuEvrtlEDe8gMqDb+SO+9hjC/pLekeSCryf9vMZlCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+      "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
+      "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "@typescript-eslint/utils": "5.62.0",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -2085,6 +4160,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -2103,24 +4188,36 @@
       }
     },
     "node_modules/array-includes": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
-      "integrity": "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "is-string": "^1.0.7"
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/array.prototype.findlast": {
@@ -2136,6 +4233,28 @@
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
         "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2221,6 +4340,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -2285,6 +4411,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
@@ -2320,12 +4466,97 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/babel-plugin-polyfill-corejs2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
+      "integrity": "sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.7",
+        "@babel/helper-define-polyfill-provider": "^0.6.5",
+        "semver": "^6.3.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz",
+      "integrity": "sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.5",
+        "core-js-compat": "^3.43.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-regenerator": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz",
+      "integrity": "sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-react-remove-prop-types": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
+      "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/babel-preset-react-app": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-10.1.0.tgz",
+      "integrity": "sha512-f9B1xMdnkCIqe+2dHrJsoQFRz7reChaAHE/65SdaykPklQqhme2WaC08oD3is77x9ff98/9EazAKFDZv5rFEQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.16.0",
+        "@babel/plugin-proposal-class-properties": "^7.16.0",
+        "@babel/plugin-proposal-decorators": "^7.16.4",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.16.0",
+        "@babel/plugin-proposal-numeric-separator": "^7.16.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.16.0",
+        "@babel/plugin-proposal-private-methods": "^7.16.0",
+        "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
+        "@babel/plugin-transform-flow-strip-types": "^7.16.0",
+        "@babel/plugin-transform-react-display-name": "^7.16.0",
+        "@babel/plugin-transform-runtime": "^7.16.4",
+        "@babel/preset-env": "^7.16.4",
+        "@babel/preset-react": "^7.16.0",
+        "@babel/preset-typescript": "^7.16.0",
+        "@babel/runtime": "^7.16.3",
+        "babel-plugin-macros": "^3.1.0",
+        "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.16",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.16.tgz",
+      "integrity": "sha512-KeUZdBuxngy825i8xvzaK1Ncnkx0tBmb3k8DkEuqjKRkmtvNTjey2ZsNeh8Dw4lfKvbCOu9oeNx2TKm2vHqcRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2344,7 +4575,6 @@
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -2353,9 +4583,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
-      "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "dev": true,
       "funding": [
         {
@@ -2373,10 +4603,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001716",
-        "electron-to-chromium": "^1.5.149",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2445,9 +4676,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001718",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
-      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
+      "version": "1.0.30001765",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001765.tgz",
+      "integrity": "sha512-LWcNtSyZrakjECqmpP4qdg0MMGdN368D7X8XvvAqOcqMv0RxnlqVKZl2V6/mBR68oYMxOZPLw/gO7DuisMHUvQ==",
       "dev": true,
       "funding": [
         {
@@ -2543,6 +4774,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/confusing-browser-globals": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
+      "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2556,6 +4794,20 @@
       "integrity": "sha512-Sz4PP4ZA+Rq4II21qkNqOEDTDrCvcANId3xpIgB34NDkWc3UduWj2dqEtN9yZIq8Dk3HyPI33x9sqqU5C8sr0g==",
       "hasInstallScript": true,
       "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/core-js-compat": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.47.0.tgz",
+      "integrity": "sha512-IGfuznZ/n7Kp9+nypamBhvwdwLsW6KC8IOaURw2doAK5e98AG3acVLdh0woOnEqCfUtS+Vu882JE4k/DAm3ItQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.0"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -2606,6 +4858,13 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -2735,6 +4994,19 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -2774,11 +5046,18 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.155",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.155.tgz",
-      "integrity": "sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng==",
+      "version": "1.5.267",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
+      "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -2790,9 +5069,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.23.9",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
-      "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
+      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2800,18 +5079,18 @@
         "arraybuffer.prototype.slice": "^1.0.4",
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
+        "call-bound": "^1.0.4",
         "data-view-buffer": "^1.0.2",
         "data-view-byte-length": "^1.0.2",
         "data-view-byte-offset": "^1.0.1",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "es-set-tostringtag": "^2.1.0",
         "es-to-primitive": "^1.3.0",
         "function.prototype.name": "^1.1.8",
-        "get-intrinsic": "^1.2.7",
-        "get-proto": "^1.0.0",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
         "get-symbol-description": "^1.1.0",
         "globalthis": "^1.0.4",
         "gopd": "^1.2.0",
@@ -2823,21 +5102,24 @@
         "is-array-buffer": "^3.0.5",
         "is-callable": "^1.2.7",
         "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
         "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
         "is-shared-array-buffer": "^1.0.4",
         "is-string": "^1.1.1",
         "is-typed-array": "^1.1.15",
-        "is-weakref": "^1.1.0",
+        "is-weakref": "^1.1.1",
         "math-intrinsics": "^1.1.0",
-        "object-inspect": "^1.13.3",
+        "object-inspect": "^1.13.4",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.7",
         "own-keys": "^1.0.1",
-        "regexp.prototype.flags": "^1.5.3",
+        "regexp.prototype.flags": "^1.5.4",
         "safe-array-concat": "^1.1.3",
         "safe-push-apply": "^1.0.0",
         "safe-regex-test": "^1.1.0",
         "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
         "string.prototype.trim": "^1.2.10",
         "string.prototype.trimend": "^1.0.9",
         "string.prototype.trimstart": "^1.0.8",
@@ -2846,7 +5128,7 @@
         "typed-array-byte-offset": "^1.0.4",
         "typed-array-length": "^1.0.7",
         "unbox-primitive": "^1.1.0",
-        "which-typed-array": "^1.1.18"
+        "which-typed-array": "^1.1.19"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3094,6 +5376,237 @@
         "eslint": ">=7.0.0"
       }
     },
+    "node_modules/eslint-config-react-app": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz",
+      "integrity": "sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.16.0",
+        "@babel/eslint-parser": "^7.16.3",
+        "@rushstack/eslint-patch": "^1.1.0",
+        "@typescript-eslint/eslint-plugin": "^5.5.0",
+        "@typescript-eslint/parser": "^5.5.0",
+        "babel-preset-react-app": "^10.0.1",
+        "confusing-browser-globals": "^1.0.11",
+        "eslint-plugin-flowtype": "^8.0.3",
+        "eslint-plugin-import": "^2.25.3",
+        "eslint-plugin-jest": "^25.3.0",
+        "eslint-plugin-jsx-a11y": "^6.5.1",
+        "eslint-plugin-react": "^7.27.1",
+        "eslint-plugin-react-hooks": "^4.3.0",
+        "eslint-plugin-testing-library": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-flowtype": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-8.0.3.tgz",
+      "integrity": "sha512-dX8l6qUL6O+fYPtpNRideCFSpmWOUVx5QcaGLVqe/vlDiBSe4vYljDWDETwnyFzpl7By/WVIu6rcrniCgH9BqQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "string-natural-compare": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@babel/plugin-syntax-flow": "^7.14.5",
+        "@babel/plugin-transform-react-jsx": "^7.14.9",
+        "eslint": "^8.1.0"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-jest": {
+      "version": "25.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.7.0.tgz",
+      "integrity": "sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^4.0.0 || ^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
     "node_modules/eslint-plugin-prettier": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.4.0.tgz",
@@ -3182,6 +5695,23 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.11.1.tgz",
+      "integrity": "sha512-5eX9e1Kc2PqVRed3taaLnAAqPZGEX75C+M/rXzUAI3wIg/ZxzUm1OVAwfe/O+vE+6YXOLetSe9g5GKD2ecXipw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^5.58.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "eslint": "^7.5.0 || ^8.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -3313,6 +5843,36 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3356,7 +5916,6 @@
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -3603,15 +6162,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/globalthis": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
@@ -3627,6 +6177,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {
@@ -4120,13 +6691,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -4438,6 +7021,26 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4495,6 +7098,13 @@
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "license": "MIT"
     },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4540,13 +7150,22 @@
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -4566,6 +7185,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {
@@ -4600,6 +7229,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
@@ -4629,9 +7265,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4731,6 +7367,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/object.values": {
@@ -4917,7 +7568,6 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -5260,6 +7910,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/regenerate-unicode-properties": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.2.tgz",
+      "integrity": "sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerate": "^1.4.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -5279,6 +7949,44 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexpu-core": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
+      "integrity": "sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^10.2.2",
+        "regjsgen": "^0.8.0",
+        "regjsparser": "^0.13.0",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regjsgen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/regjsparser": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
+      "integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "jsesc": "~3.1.0"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
       }
     },
     "node_modules/resolve": {
@@ -5665,6 +8373,16 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -5682,6 +8400,42 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string-natural-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/string-natural-compare/-/string-natural-compare-3.0.1.tgz",
+      "integrity": "sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -5795,6 +8549,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -5877,7 +8641,6 @@
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -5890,6 +8653,55 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5995,6 +8807,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -6014,10 +8841,54 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/unicode-canonical-property-names-ecmascript": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+      "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-value-ecmascript": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.1.tgz",
+      "integrity": "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-property-aliases-ecmascript": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
+      "integrity": "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {

--- a/web/package.json
+++ b/web/package.json
@@ -61,6 +61,7 @@
     "autoprefixer": "^10.4.19",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-config-react-app": "^7.0.1",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/web/src/components/AppBreadcrumb.js
+++ b/web/src/components/AppBreadcrumb.js
@@ -32,7 +32,9 @@ const AppBreadcrumb = () => {
 
   return (
     <>
-      <div className="fs-2 fw-semibold">{breadcrumbs.length > 0 ? [...breadcrumbs].pop().name : 'Home'}</div>
+      <div className="fs-2 fw-semibold">
+        {breadcrumbs.length > 0 ? [...breadcrumbs].pop().name : 'Home'}
+      </div>
       <CBreadcrumb className="mb-4">
         <CBreadcrumbItem href="/">Home</CBreadcrumbItem>
         {breadcrumbs.map((breadcrumb, index) => {

--- a/web/src/components/header/AppHeaderDropdown.js
+++ b/web/src/components/header/AppHeaderDropdown.js
@@ -7,12 +7,7 @@ import {
   CDropdownMenu,
   CDropdownToggle,
 } from '@coreui/react-pro'
-import {
-  cilLockLocked,
-  cilSettings,
-  cilUser,
-  cilAccountLogout,
-} from '@coreui/icons'
+import { cilLockLocked, cilSettings, cilUser, cilAccountLogout } from '@coreui/icons'
 import CIcon from '@coreui/icons-react'
 
 const AppHeaderDropdown = () => {

--- a/web/src/components/index.js
+++ b/web/src/components/index.js
@@ -5,11 +5,4 @@ import AppFooter from './AppFooter'
 import AppHeader from './AppHeader'
 import AppSidebar from './AppSidebar'
 
-export {
-  AppAside,
-  AppBreadcrumb,
-  AppContent,
-  AppFooter,
-  AppHeader,
-  AppSidebar,
-}
+export { AppAside, AppBreadcrumb, AppContent, AppFooter, AppHeader, AppSidebar }

--- a/web/src/configs/assetColumns.js
+++ b/web/src/configs/assetColumns.js
@@ -1,64 +1,64 @@
 /**
  * Asset column configuration for the Assets view.
- * 
+ *
  * This file defines all available columns from the assets table,
  * their UI-friendly labels, filter types, and default visibility.
- * 
+ *
  * Adding a new column:
  * 1. Add entry to ASSET_COLUMNS with the DB column name as key
  * 2. Set appropriate filterType, defaultVisible, and other properties
  * 3. If dropdown filter, add options to dropdownOptions or reference an enum
  */
 
-import { ASSET_CLASSES } from '../enums';
+import { ASSET_CLASSES } from '../enums'
 
 // Filter type constants
 export const FILTER_TYPES = {
   TEXT: 'text',
   DROPDOWN: 'dropdown',
-  NONE: 'none'
-};
+  NONE: 'none',
+}
 
 // Dropdown options for specific columns
 export const DROPDOWN_OPTIONS = {
   class_type: [
     { value: '', label: 'All' },
     { value: 'provider', label: 'Provider' },
-    { value: 'broker', label: 'Broker' }
+    { value: 'broker', label: 'Broker' },
   ],
   primary_id_source: [
     { value: '', label: 'All' },
     { value: 'provider', label: 'Provider' },
     { value: 'matcher', label: 'Matcher' },
-    { value: 'manual', label: 'Manual' }
+    { value: 'manual', label: 'Manual' },
   ],
   identity_match_type: [
     { value: '', label: 'All' },
     { value: 'exact_alias', label: 'Exact Alias' },
-    { value: 'fuzzy_symbol', label: 'Fuzzy Symbol' }
+    { value: 'fuzzy_symbol', label: 'Fuzzy Symbol' },
   ],
   asset_class_group: [
     { value: '', label: 'All' },
     { value: 'securities', label: 'Securities' },
-    { value: 'crypto', label: 'Crypto' }
-  ]
-};
+    { value: 'crypto', label: 'Crypto' },
+  ],
+}
 
 // Generate asset_class dropdown options from enum
 const formatLabel = (value) => {
-  if (!value) return '';
-  const withSpaces = value.replace(/_/g, ' ');
-  return withSpaces.charAt(0).toUpperCase() + withSpaces.slice(1);
-};
+  if (!value) return ''
+  const withSpaces = value.replace(/_/g, ' ')
+  return withSpaces.charAt(0).toUpperCase() + withSpaces.slice(1)
+}
 
 DROPDOWN_OPTIONS.asset_class = [
   { value: '', label: 'All' },
-  ...ASSET_CLASSES.map((ac) => ({ value: ac, label: formatLabel(ac) }))
-];
+  ...ASSET_CLASSES.map((ac) => ({ value: ac, label: formatLabel(ac) })),
+]
 
 /**
  * Column definitions for the assets table.
- * 
+ *
  * Properties:
  * - key: DB column name (used as unique identifier)
  * - label: UI-friendly display name
@@ -78,7 +78,7 @@ export const ASSET_COLUMNS = {
     defaultVisible: false,
     sortable: true,
     apiFilterKey: 'id',
-    apiExactMatch: true
+    apiExactMatch: true,
   },
   symbol: {
     key: 'symbol',
@@ -88,7 +88,7 @@ export const ASSET_COLUMNS = {
     sortable: true,
     props: { className: 'fw-semibold' },
     apiFilterKey: 'symbol_like',
-    apiExactMatch: false
+    apiExactMatch: false,
   },
   name: {
     key: 'name',
@@ -97,7 +97,7 @@ export const ASSET_COLUMNS = {
     defaultVisible: true,
     sortable: true,
     apiFilterKey: 'name_like',
-    apiExactMatch: false
+    apiExactMatch: false,
   },
   class_name: {
     key: 'class_name',
@@ -106,7 +106,7 @@ export const ASSET_COLUMNS = {
     defaultVisible: true,
     sortable: true,
     apiFilterKey: 'class_name_like',
-    apiExactMatch: false
+    apiExactMatch: false,
   },
   class_type: {
     key: 'class_type',
@@ -116,7 +116,7 @@ export const ASSET_COLUMNS = {
     sortable: false,
     render: 'badge',
     apiFilterKey: 'class_type',
-    apiExactMatch: true
+    apiExactMatch: true,
   },
   asset_class: {
     key: 'asset_class',
@@ -126,7 +126,7 @@ export const ASSET_COLUMNS = {
     sortable: false,
     render: 'badge',
     apiFilterKey: 'asset_class',
-    apiExactMatch: true
+    apiExactMatch: true,
   },
   exchange: {
     key: 'exchange',
@@ -135,7 +135,7 @@ export const ASSET_COLUMNS = {
     defaultVisible: true,
     sortable: true,
     apiFilterKey: 'exchange_like',
-    apiExactMatch: false
+    apiExactMatch: false,
   },
   base_currency: {
     key: 'base_currency',
@@ -144,7 +144,7 @@ export const ASSET_COLUMNS = {
     defaultVisible: true,
     sortable: true,
     apiFilterKey: 'base_currency_like',
-    apiExactMatch: false
+    apiExactMatch: false,
   },
   quote_currency: {
     key: 'quote_currency',
@@ -153,7 +153,7 @@ export const ASSET_COLUMNS = {
     defaultVisible: true,
     sortable: true,
     apiFilterKey: 'quote_currency_like',
-    apiExactMatch: false
+    apiExactMatch: false,
   },
   country: {
     key: 'country',
@@ -162,7 +162,7 @@ export const ASSET_COLUMNS = {
     defaultVisible: true,
     sortable: true,
     apiFilterKey: 'country_like',
-    apiExactMatch: false
+    apiExactMatch: false,
   },
   external_id: {
     key: 'external_id',
@@ -171,7 +171,7 @@ export const ASSET_COLUMNS = {
     defaultVisible: false,
     sortable: true,
     apiFilterKey: 'external_id_like',
-    apiExactMatch: false
+    apiExactMatch: false,
   },
   primary_id: {
     key: 'primary_id',
@@ -180,7 +180,7 @@ export const ASSET_COLUMNS = {
     defaultVisible: true,
     sortable: true,
     apiFilterKey: 'primary_id_like',
-    apiExactMatch: false
+    apiExactMatch: false,
   },
   primary_id_source: {
     key: 'primary_id_source',
@@ -190,7 +190,7 @@ export const ASSET_COLUMNS = {
     sortable: true,
     render: 'badge',
     apiFilterKey: 'primary_id_source',
-    apiExactMatch: true
+    apiExactMatch: true,
   },
   matcher_symbol: {
     key: 'matcher_symbol',
@@ -199,7 +199,7 @@ export const ASSET_COLUMNS = {
     defaultVisible: false,
     sortable: true,
     apiFilterKey: 'matcher_symbol_like',
-    apiExactMatch: false
+    apiExactMatch: false,
   },
   identity_conf: {
     key: 'identity_conf',
@@ -207,7 +207,7 @@ export const ASSET_COLUMNS = {
     filterType: FILTER_TYPES.NONE,
     defaultVisible: false,
     sortable: true,
-    render: 'number'
+    render: 'number',
   },
   identity_match_type: {
     key: 'identity_match_type',
@@ -217,7 +217,7 @@ export const ASSET_COLUMNS = {
     sortable: true,
     render: 'badge',
     apiFilterKey: 'identity_match_type',
-    apiExactMatch: true
+    apiExactMatch: true,
   },
   identity_updated_at: {
     key: 'identity_updated_at',
@@ -225,7 +225,7 @@ export const ASSET_COLUMNS = {
     filterType: FILTER_TYPES.NONE,
     defaultVisible: false,
     sortable: true,
-    render: 'date'
+    render: 'date',
   },
   asset_class_group: {
     key: 'asset_class_group',
@@ -235,57 +235,55 @@ export const ASSET_COLUMNS = {
     sortable: true,
     render: 'badge',
     apiFilterKey: 'asset_class_group',
-    apiExactMatch: true
+    apiExactMatch: true,
   },
   sym_norm_full: {
     key: 'sym_norm_full',
     label: 'Normalized Symbol',
     filterType: FILTER_TYPES.NONE,
     defaultVisible: false,
-    sortable: true
+    sortable: true,
   },
   sym_norm_root: {
     key: 'sym_norm_root',
     label: 'Root Symbol',
     filterType: FILTER_TYPES.NONE,
     defaultVisible: false,
-    sortable: true
-  }
-};
+    sortable: true,
+  },
+}
 
 /**
  * Get array of all column keys in display order.
  */
-export const getColumnKeys = () => Object.keys(ASSET_COLUMNS);
+export const getColumnKeys = () => Object.keys(ASSET_COLUMNS)
 
 /**
  * Get array of column keys that are visible by default.
  */
-export const getDefaultVisibleColumns = () => 
+export const getDefaultVisibleColumns = () =>
   Object.values(ASSET_COLUMNS)
-    .filter(col => col.defaultVisible)
-    .map(col => col.key);
+    .filter((col) => col.defaultVisible)
+    .map((col) => col.key)
 
 /**
  * Get array of column keys that use text input filtering.
  */
 export const getTextFilterKeys = () =>
   Object.values(ASSET_COLUMNS)
-    .filter(col => col.filterType === FILTER_TYPES.TEXT)
-    .map(col => col.key);
+    .filter((col) => col.filterType === FILTER_TYPES.TEXT)
+    .map((col) => col.key)
 
 /**
  * Get dropdown options for a specific column.
  * @param {string} columnKey - The column key
  * @returns {Array|null} - Array of {value, label} options or null if not dropdown
  */
-export const getDropdownOptions = (columnKey) => 
-  DROPDOWN_OPTIONS[columnKey] || null;
+export const getDropdownOptions = (columnKey) => DROPDOWN_OPTIONS[columnKey] || null
 
 /**
  * Get column configuration by key.
  * @param {string} columnKey - The column key
  * @returns {Object|null} - Column config object or null if not found
  */
-export const getColumnConfig = (columnKey) => 
-  ASSET_COLUMNS[columnKey] || null;
+export const getColumnConfig = (columnKey) => ASSET_COLUMNS[columnKey] || null

--- a/web/src/utils/badgeHelpers.js
+++ b/web/src/utils/badgeHelpers.js
@@ -1,0 +1,24 @@
+/**
+ * Returns badge color for class type.
+ * @param {string} class_type - 'provider' or 'broker'
+ * @returns {string} CoreUI badge color
+ */
+export const getClassBadge = (class_type) => {
+  switch (class_type) {
+    case 'provider':
+      return 'primary'
+    case 'broker':
+      return 'secondary'
+    default:
+      return 'primary'
+  }
+}
+
+/**
+ * Returns badge color for active status.
+ * @param {boolean} is_active
+ * @returns {string} CoreUI badge color
+ */
+export const getActiveBadge = (is_active) => {
+  return is_active ? 'success' : 'danger'
+}

--- a/web/src/utils/csvExport.js
+++ b/web/src/utils/csvExport.js
@@ -1,6 +1,6 @@
 /**
  * CSV Export Utility Functions
- * 
+ *
  * Provides functions to generate and download OHLCV data as CSV files.
  */
 
@@ -20,45 +20,46 @@ const formatTimestampForCSV = (timestamp) => {
  * 1. Prevents CSV injection by prefixing dangerous formula characters with a tab
  * 2. Properly escapes quotes and commas by quoting the value
  * 3. Handles newlines within values
- * 
+ *
  * CSV Injection Prevention: Values starting with =, +, -, @, or tab are prefixed with
  * a tab character to prevent Excel from interpreting them as formulas.
- * 
+ *
  * @param {string|number} value - The value to escape
  * @returns {string} Properly escaped CSV value
  */
 const escapeCSVValue = (value) => {
   // Convert to string and handle null/undefined
   const str = value == null ? '' : String(value)
-  
+
   // Check for CSV injection risk: values starting with =, +, -, @, or tab
   // These characters can be interpreted as formulas in Excel
   const dangerousChars = ['=', '+', '-', '@', '\t']
-  const needsInjectionProtection = dangerousChars.some(char => str.startsWith(char))
-  
+  const needsInjectionProtection = dangerousChars.some((char) => str.startsWith(char))
+
   // Check if value needs quoting per RFC 4180 (contains comma, quote, or newline)
-  const needsQuoting = str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')
-  
+  const needsQuoting =
+    str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')
+
   let escaped = str
-  
+
   // If value needs injection protection, prefix with tab character
   // This prevents Excel from interpreting it as a formula while keeping it readable
   if (needsInjectionProtection) {
     escaped = `\t${escaped}`
   }
-  
+
   // If value contains quotes, double them (RFC 4180 standard)
   // Do this after adding tab prefix so quotes in original value are handled
   if (escaped.includes('"')) {
     escaped = escaped.replace(/"/g, '""')
   }
-  
+
   // If value needs quoting (per RFC 4180) or has injection protection, wrap in quotes
   // The tab prefix will be inside the quotes, which is correct
   if (needsQuoting || needsInjectionProtection) {
     escaped = `"${escaped}"`
   }
-  
+
   return escaped
 }
 
@@ -78,7 +79,7 @@ export const generateCSV = (data) => {
   // CSV Rows - sort by time ascending (oldest first) for logical CSV order
   const rows = data
     .sort((a, b) => a.time - b.time)
-    .map(bar => {
+    .map((bar) => {
       const datetime = formatTimestampForCSV(bar.time)
       // Escape all values to prevent CSV injection and handle special characters
       const open = escapeCSVValue(bar.open ?? '')
@@ -86,7 +87,7 @@ export const generateCSV = (data) => {
       const low = escapeCSVValue(bar.low ?? '')
       const close = escapeCSVValue(bar.close ?? '')
       const volume = escapeCSVValue(bar.volume ?? '')
-      
+
       return `${datetime},${open},${high},${low},${close},${volume}`
     })
     .join('\n')
@@ -106,7 +107,7 @@ export const generateFilename = (symbol, dataType, interval) => {
   const symbolName = symbol?.common_symbol || symbol?.provider_symbol || 'data'
   const sanitizedSymbol = symbolName.replace(/[^a-zA-Z0-9-_]/g, '_')
   const sanitizedInterval = (interval || '').replace(/[^a-zA-Z0-9-_]/g, '_')
-  
+
   return `${sanitizedSymbol}_${dataType}_${sanitizedInterval}_${timestamp}.csv`
 }
 
@@ -149,4 +150,3 @@ export const downloadCSV = (data, symbol, dataType, interval) => {
     throw err
   }
 }
-

--- a/web/src/utils/formatting.js
+++ b/web/src/utils/formatting.js
@@ -5,20 +5,20 @@
  * @returns {string} Formatted date string or '—' if null
  */
 export const formatDate = (dateString, includeTime = true) => {
-  if (!dateString) return '—';
-  const date = new Date(dateString);
-  if (isNaN(date.getTime())) return '—';
+  if (!dateString) return '—'
+  const date = new Date(dateString)
+  if (isNaN(date.getTime())) return '—'
   const options = {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
-  };
-  if (includeTime) {
-    options.hour = '2-digit';
-    options.minute = '2-digit';
   }
-  return date.toLocaleDateString('en-US', options);
-};
+  if (includeTime) {
+    options.hour = '2-digit'
+    options.minute = '2-digit'
+  }
+  return date.toLocaleDateString('en-US', options)
+}
 
 /**
  * Format a weight (decimal 0-1) as a percentage string.
@@ -26,9 +26,9 @@ export const formatDate = (dateString, includeTime = true) => {
  * @returns {string} Formatted percentage string or '—' if null
  */
 export const formatWeight = (weight) => {
-  if (weight === null || weight === undefined) return '—';
-  return (weight * 100).toFixed(1) + '%';
-};
+  if (weight === null || weight === undefined) return '—'
+  return (weight * 100).toFixed(1) + '%'
+}
 
 /**
  * Format a weight for input field display (decimal to percentage number).
@@ -36,6 +36,6 @@ export const formatWeight = (weight) => {
  * @returns {string} Percentage value as string or empty string if null
  */
 export const formatWeightForInput = (weight) => {
-  if (weight === null || weight === undefined) return '';
-  return (weight * 100).toFixed(1);
-};
+  if (weight === null || weight === undefined) return ''
+  return (weight * 100).toFixed(1)
+}

--- a/web/src/views/assets/Assets.js
+++ b/web/src/views/assets/Assets.js
@@ -1,479 +1,496 @@
 /**
  * Assets view component with configurable columns.
- * 
+ *
  * Columns are driven by the assetColumns.js configuration file.
  * Users can toggle column visibility via the Column Selector modal.
  */
-import React, { useState, useEffect, useMemo } from 'react'; 
-import { 
-    CCard, 
-    CCardBody, 
-    CCardHeader, 
-    CCol, 
-    CRow,
-    CSmartTable,
-    CSmartPagination,
-    CDropdown,
-    CDropdownToggle,
-    CDropdownMenu,
-    CDropdownItem,
-    CFormSelect,
-    CBadge,
-    CAlert,
-    CButton,
-} from '@coreui/react-pro';
-import CIcon from '@coreui/icons-react';
-import { cilSettings } from '@coreui/icons';
-import { getAssets } from '../services/registry_api';
-import { 
-    ASSET_COLUMNS, 
-    FILTER_TYPES, 
-    getDefaultVisibleColumns, 
-    getTextFilterKeys,
-    getDropdownOptions 
-} from '../../configs/assetColumns';
-import ColumnSelectorModal from './ColumnSelectorModal';
+import React, { useState, useEffect, useMemo } from 'react'
+import {
+  CCard,
+  CCardBody,
+  CCardHeader,
+  CCol,
+  CRow,
+  CSmartTable,
+  CSmartPagination,
+  CDropdown,
+  CDropdownToggle,
+  CDropdownMenu,
+  CDropdownItem,
+  CFormSelect,
+  CBadge,
+  CAlert,
+  CButton,
+} from '@coreui/react-pro'
+import CIcon from '@coreui/icons-react'
+import { cilSettings } from '@coreui/icons'
+import { getAssets } from '../services/registry_api'
+import {
+  ASSET_COLUMNS,
+  FILTER_TYPES,
+  getDefaultVisibleColumns,
+  getTextFilterKeys,
+  getDropdownOptions,
+} from '../../configs/assetColumns'
+import ColumnSelectorModal from './ColumnSelectorModal'
 
 // LocalStorage key for persisting column visibility preferences
-const STORAGE_KEY = 'quasar_assets_visible_columns';
+const STORAGE_KEY = 'quasar_assets_visible_columns'
 
 const Assets = () => {
-    // State
-    const [assets, setAssets] = useState([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState(null);
-    const [totalItems, setTotalItems] = useState(0); 
-    const [activePage, setActivePage] = useState(1); 
-    const [itemsPerPage, setItemsPerPage] = useState(10); 
-    const [sorter, setSorter] = useState({}); 
-    const [columnFilter, setColumnFilter] = useState({}); 
-    const [liveTextInputFilters, setLiveTextInputFilters] = useState({});
-    
-    // Column visibility state (initialized from localStorage or config defaults)
-    const [visibleColumns, setVisibleColumns] = useState(() => {
-        try {
-            const saved = localStorage.getItem(STORAGE_KEY);
-            if (saved) {
-                const parsed = JSON.parse(saved);
-                // Validate that parsed is an array of strings
-                if (Array.isArray(parsed) && parsed.every(k => typeof k === 'string')) {
-                    return parsed;
-                }
-            }
-        } catch (e) {
-            console.warn('Failed to load column preferences from localStorage:', e);
+  // State
+  const [assets, setAssets] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [totalItems, setTotalItems] = useState(0)
+  const [activePage, setActivePage] = useState(1)
+  const [itemsPerPage, setItemsPerPage] = useState(10)
+  const [sorter, setSorter] = useState({})
+  const [columnFilter, setColumnFilter] = useState({})
+  const [liveTextInputFilters, setLiveTextInputFilters] = useState({})
+
+  // Column visibility state (initialized from localStorage or config defaults)
+  const [visibleColumns, setVisibleColumns] = useState(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY)
+      if (saved) {
+        const parsed = JSON.parse(saved)
+        // Validate that parsed is an array of strings
+        if (Array.isArray(parsed) && parsed.every((k) => typeof k === 'string')) {
+          return parsed
         }
-        return getDefaultVisibleColumns();
-    });
-    const [isColumnSelectorVisible, setIsColumnSelectorVisible] = useState(false);
+      }
+    } catch (e) {
+      console.warn('Failed to load column preferences from localStorage:', e)
+    }
+    return getDefaultVisibleColumns()
+  })
+  const [isColumnSelectorVisible, setIsColumnSelectorVisible] = useState(false)
 
-    // Persist column visibility to localStorage when it changes
-    useEffect(() => {
-        try {
-            localStorage.setItem(STORAGE_KEY, JSON.stringify(visibleColumns));
-        } catch (e) {
-            console.warn('Failed to save column preferences to localStorage:', e);
-        }
-    }, [visibleColumns]);
+  // Persist column visibility to localStorage when it changes
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(visibleColumns))
+    } catch (e) {
+      console.warn('Failed to save column preferences to localStorage:', e)
+    }
+  }, [visibleColumns])
 
-    // Get text filter keys from config
-    const textInputFilterKeys = useMemo(() => getTextFilterKeys(), []);
+  // Get text filter keys from config
+  const textInputFilterKeys = useMemo(() => getTextFilterKeys(), [])
 
-    // Badge color mappings
-    const classTypeBadgeColors = {
-        provider: 'primary',
-        broker: 'secondary'
-    };
+  // Badge color mappings
+  const classTypeBadgeColors = {
+    provider: 'primary',
+    broker: 'secondary',
+  }
 
-    const assetClassBadgeColors = {
-        equity: 'success',
-        fund: 'info',
-        etf: 'warning',
-        bond: 'dark',
-        crypto: 'danger',
-        currency: 'primary',
-    };
+  const assetClassBadgeColors = {
+    equity: 'success',
+    fund: 'info',
+    etf: 'warning',
+    bond: 'dark',
+    crypto: 'danger',
+    currency: 'primary',
+  }
 
-    const primaryIdSourceBadgeColors = {
-        provider: 'info',
-        matcher: 'success',
-        manual: 'warning'
-    };
+  const primaryIdSourceBadgeColors = {
+    provider: 'info',
+    matcher: 'success',
+    manual: 'warning',
+  }
 
-    const identityMatchTypeBadgeColors = {
-        exact_alias: 'success',
-        fuzzy_symbol: 'warning'
-    };
+  const identityMatchTypeBadgeColors = {
+    exact_alias: 'success',
+    fuzzy_symbol: 'warning',
+  }
 
-    const assetClassGroupBadgeColors = {
-        securities: 'primary',
-        crypto: 'danger'
-    };
+  const assetClassGroupBadgeColors = {
+    securities: 'primary',
+    crypto: 'danger',
+  }
 
-    // Utility function for formatting labels
-    const formatLabel = (value) => {
-        if (!value) return '';
-        const withSpaces = value.replace(/_/g, ' ');
-        return withSpaces.charAt(0).toUpperCase() + withSpaces.slice(1);
-    };
+  // Utility function for formatting labels
+  const formatLabel = (value) => {
+    if (!value) return ''
+    const withSpaces = value.replace(/_/g, ' ')
+    return withSpaces.charAt(0).toUpperCase() + withSpaces.slice(1)
+  }
 
-    // Utility function to format confidence as percentage
-    const formatConfidence = (value) => {
-        if (value === null || value === undefined) return '';
-        return `${Math.round(value)}%`;
-    };
+  // Utility function to format confidence as percentage
+  const formatConfidence = (value) => {
+    if (value === null || value === undefined) return ''
+    return `${Math.round(value)}%`
+  }
 
-    // Utility function to format date
-    const formatDate = (value) => {
-        if (!value) return '';
-        try {
-            return new Date(value).toLocaleDateString();
-        } catch {
-            return value;
-        }
-    };
+  // Utility function to format date
+  const formatDate = (value) => {
+    if (!value) return ''
+    try {
+      return new Date(value).toLocaleDateString()
+    } catch {
+      return value
+    }
+  }
 
-    // Factory function to create dropdown filter component
-    const createDropdownFilter = (columnKey, options, setColumnFilter) => {
-        return (columnValues, setFilterValue, currentFilterValue) => {
-            const currentLabel = options.find(opt => opt.value === currentFilterValue)?.label || 'All';
+  // Factory function to create dropdown filter component
+  const createDropdownFilter = (columnKey, options, setColumnFilter) => {
+    return (columnValues, setFilterValue, currentFilterValue) => {
+      const currentLabel = options.find((opt) => opt.value === currentFilterValue)?.label || 'All'
 
-            return (
-                <CDropdown size="sm">
-                    <CDropdownToggle size="sm" color="secondary" variant="outline" style={{ width: '100%', textAlign: 'start' }}>
-                        {currentLabel}
-                    </CDropdownToggle>
-                    <CDropdownMenu style={{ maxHeight: '200px', overflowY: 'auto', width: '100%' }}>
-                        {options.map(option => (
-                            <CDropdownItem
-                                key={option.value}
-                                active={option.value === currentFilterValue}
-                                onClick={() => {
-                                    // Update CSmartTable's internal state
-                                    setFilterValue(option.value);
-                                    // Update parent's columnFilter state for API calls
-                                    setColumnFilter(prev => {
-                                        const updated = { ...prev };
-                                        if (option.value === '') {
-                                            // Remove filter when "All" is selected
-                                            delete updated[columnKey];
-                                        } else {
-                                            // Set filter value
-                                            updated[columnKey] = option.value;
-                                        }
-                                        return updated;
-                                    });
-                                }}
-                            >
-                                {option.label}
-                            </CDropdownItem>
-                        ))}
-                    </CDropdownMenu>
-                </CDropdown>
-            );
-        };
-    };
-
-    // Generate columns array from configuration based on visible columns
-    const columns = useMemo(() => {
-        return visibleColumns
-            .filter(key => ASSET_COLUMNS[key]) // Ensure column exists in config
-            .map(key => {
-                const config = ASSET_COLUMNS[key];
-                const column = {
-                    key: config.key,
-                    label: config.label,
-                    _props: config.props || {},
-                    sorter: config.sortable !== false,
-                };
-
-                // Handle filter type
-                if (config.filterType === FILTER_TYPES.DROPDOWN) {
-                    const options = getDropdownOptions(config.key);
-                    if (options) {
-                        column.filter = createDropdownFilter(config.key, options, setColumnFilter);
-                    }
-                    column.sorter = false; // Dropdowns typically don't sort
-                } else if (config.filterType === FILTER_TYPES.NONE) {
-                    column.filter = false;
-                }
-                // TEXT filter type uses default behavior (text input)
-
-                return column;
-            });
-    }, [visibleColumns, columnFilter, setColumnFilter]);
-
-    // Generate scoped columns for custom rendering
-    const scopedColumns = useMemo(() => {
-        const scoped = {};
-
-        visibleColumns.forEach(key => {
-            const config = ASSET_COLUMNS[key];
-            if (!config) return;
-
-            // Handle badge rendering
-            if (config.render === 'badge') {
-                if (key === 'class_type') {
-                    scoped[key] = (item) => (
-                        <td>
-                            <CBadge color={classTypeBadgeColors[item.class_type] || 'light'}>
-                                {item.class_type ? formatLabel(item.class_type) : ''}
-                            </CBadge>
-                        </td>
-                    );
-                } else if (key === 'asset_class') {
-                    scoped[key] = (item) => (
-                        <td>
-                            <CBadge color={assetClassBadgeColors[item.asset_class] || 'secondary'}>
-                                {item.asset_class ? formatLabel(item.asset_class) : ''}
-                            </CBadge>
-                        </td>
-                    );
-                } else if (key === 'primary_id_source') {
-                    scoped[key] = (item) => (
-                        <td>
-                            {item.primary_id_source ? (
-                                <CBadge color={primaryIdSourceBadgeColors[item.primary_id_source] || 'light'}>
-                                    {formatLabel(item.primary_id_source)}
-                                </CBadge>
-                            ) : ''}
-                        </td>
-                    );
-                } else if (key === 'identity_match_type') {
-                    scoped[key] = (item) => (
-                        <td>
-                            {item.identity_match_type ? (
-                                <CBadge color={identityMatchTypeBadgeColors[item.identity_match_type] || 'light'}>
-                                    {formatLabel(item.identity_match_type)}
-                                </CBadge>
-                            ) : ''}
-                        </td>
-                    );
-                } else if (key === 'asset_class_group') {
-                    scoped[key] = (item) => (
-                        <td>
-                            {item.asset_class_group ? (
-                                <CBadge color={assetClassGroupBadgeColors[item.asset_class_group] || 'light'}>
-                                    {formatLabel(item.asset_class_group)}
-                                </CBadge>
-                            ) : ''}
-                        </td>
-                    );
-                }
-            }
-            // Handle number rendering (confidence)
-            else if (config.render === 'number') {
-                if (key === 'identity_conf') {
-                    scoped[key] = (item) => (
-                        <td>{formatConfidence(item.identity_conf)}</td>
-                    );
-                }
-            }
-            // Handle date rendering
-            else if (config.render === 'date') {
-                scoped[key] = (item) => (
-                    <td>{formatDate(item[key])}</td>
-                );
-            }
-        });
-
-        return scoped;
-    }, [visibleColumns]);
-
-    const fetchAssetsData = async () => { 
-        setLoading(true);
-        const apiParams = {
-            limit: itemsPerPage,
-            offset: (activePage - 1) * itemsPerPage,
-        };
-
-        if (sorter && sorter.column) {
-            apiParams.sort_by = sorter.column;
-            apiParams.sort_order = sorter.direction || 'asc';
-        }
-        
-        // Iterate over the main columnFilter for API params
-        for (const key in columnFilter) {
-            if (columnFilter[key]) {
-                if (textInputFilterKeys.includes(key)) {
-                    apiParams[`${key}_like`] = columnFilter[key];
-                } else {
-                    apiParams[key] = columnFilter[key]; 
-                }
-            }
-        }
-        
-        console.log(`[Assets.js] fetchAssetsData: For activePage=${activePage}, itemsPerPage=${itemsPerPage}. Requesting with API params: ${JSON.stringify(apiParams)}`);
-
-        try {
-            const data = await getAssets(apiParams);
-            console.log(`[Assets.js] fetchAssetsData: API Response for page ${activePage}: items_count=${data.items?.length}, total_items_from_api=${data.total_items}`);
-            
-            setAssets(data.items || []);
-            setTotalItems(data.total_items || 0); 
-
-        } catch (err) {
-            console.error(`[Assets.js] fetchAssetsData: Error fetching assets for page ${activePage}:`, err);
-            setError(err.message || 'Failed to fetch assets');
-            setAssets([]); 
-            setTotalItems(0); 
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    // useEffect for debouncing live text input filters
-    useEffect(() => {
-        const handler = setTimeout(() => {
-            setColumnFilter(prevMainFilters => {
-                const newMainFilters = { ...prevMainFilters };
-
-                textInputFilterKeys.forEach(key => {
-                    if (liveTextInputFilters[key]) {
-                        newMainFilters[key] = liveTextInputFilters[key];
+      return (
+        <CDropdown size="sm">
+          <CDropdownToggle
+            size="sm"
+            color="secondary"
+            variant="outline"
+            style={{ width: '100%', textAlign: 'start' }}
+          >
+            {currentLabel}
+          </CDropdownToggle>
+          <CDropdownMenu style={{ maxHeight: '200px', overflowY: 'auto', width: '100%' }}>
+            {options.map((option) => (
+              <CDropdownItem
+                key={option.value}
+                active={option.value === currentFilterValue}
+                onClick={() => {
+                  // Update CSmartTable's internal state
+                  setFilterValue(option.value)
+                  // Update parent's columnFilter state for API calls
+                  setColumnFilter((prev) => {
+                    const updated = { ...prev }
+                    if (option.value === '') {
+                      // Remove filter when "All" is selected
+                      delete updated[columnKey]
                     } else {
-                        delete newMainFilters[key];
+                      // Set filter value
+                      updated[columnKey] = option.value
                     }
-                });
-                return newMainFilters;
-            });
-            setActivePage(1);
-        }, 1000);
+                    return updated
+                  })
+                }}
+              >
+                {option.label}
+              </CDropdownItem>
+            ))}
+          </CDropdownMenu>
+        </CDropdown>
+      )
+    }
+  }
 
-        return () => {
-            clearTimeout(handler);
-        };
-    }, [liveTextInputFilters, textInputFilterKeys]);
-
-    useEffect(() => {
-        setError(null); 
-        console.log(`[Assets.js] useEffect: Triggering fetch. Current state: activePage=${activePage}, itemsPerPage=${itemsPerPage}, sorter=${JSON.stringify(sorter)}, columnFilter=${JSON.stringify(columnFilter)}`);
-        fetchAssetsData(); 
-    }, [activePage, itemsPerPage, sorter, columnFilter]);
-
-    const calculatedPages = totalItems > 0 ? Math.ceil(totalItems / itemsPerPage) : 1;
-
-    const handleItemsPerPageChange = (event) => {
-        const newSize = parseInt(event.target.value, 10);
-        console.log(`[Assets.js] handleItemsPerPageChange: newSize=${newSize}. Current itemsPerPage state is ${itemsPerPage}.`);
-        setActivePage(1);
-        setItemsPerPage(newSize);
-    };
-
-    const handleSorterChange = (sorterData) => {
-        console.log('[Assets.js] handleSorterChange:', sorterData);
-
-        // CSmartTable provides SorterValue: { column: string, state: 'asc' | 'desc' | 0 }
-        // When resetable=true, state can be 0 (null/cleared) on third click
-
-        if (!sorterData) {
-            // No sorting - clear state
-            setSorter({});
-            setActivePage(1);
-            return;
+  // Generate columns array from configuration based on visible columns
+  const columns = useMemo(() => {
+    return visibleColumns
+      .filter((key) => ASSET_COLUMNS[key]) // Ensure column exists in config
+      .map((key) => {
+        const config = ASSET_COLUMNS[key]
+        const column = {
+          key: config.key,
+          label: config.label,
+          _props: config.props || {},
+          sorter: config.sortable !== false,
         }
 
-        // Handle single sorter (non-multiple mode)
-        if (sorterData.column && sorterData.state !== 0) {
-            setSorter({
-                column: sorterData.column,
-                direction: sorterData.state  // Map 'state' to 'direction' for API
-            });
-            setActivePage(1);
+        // Handle filter type
+        if (config.filterType === FILTER_TYPES.DROPDOWN) {
+          const options = getDropdownOptions(config.key)
+          if (options) {
+            column.filter = createDropdownFilter(config.key, options, setColumnFilter)
+          }
+          column.sorter = false // Dropdowns typically don't sort
+        } else if (config.filterType === FILTER_TYPES.NONE) {
+          column.filter = false
+        }
+        // TEXT filter type uses default behavior (text input)
+
+        return column
+      })
+  }, [visibleColumns, columnFilter, setColumnFilter])
+
+  // Generate scoped columns for custom rendering
+  const scopedColumns = useMemo(() => {
+    const scoped = {}
+
+    visibleColumns.forEach((key) => {
+      const config = ASSET_COLUMNS[key]
+      if (!config) return
+
+      // Handle badge rendering
+      if (config.render === 'badge') {
+        if (key === 'class_type') {
+          scoped[key] = (item) => (
+            <td>
+              <CBadge color={classTypeBadgeColors[item.class_type] || 'light'}>
+                {item.class_type ? formatLabel(item.class_type) : ''}
+              </CBadge>
+            </td>
+          )
+        } else if (key === 'asset_class') {
+          scoped[key] = (item) => (
+            <td>
+              <CBadge color={assetClassBadgeColors[item.asset_class] || 'secondary'}>
+                {item.asset_class ? formatLabel(item.asset_class) : ''}
+              </CBadge>
+            </td>
+          )
+        } else if (key === 'primary_id_source') {
+          scoped[key] = (item) => (
+            <td>
+              {item.primary_id_source ? (
+                <CBadge color={primaryIdSourceBadgeColors[item.primary_id_source] || 'light'}>
+                  {formatLabel(item.primary_id_source)}
+                </CBadge>
+              ) : (
+                ''
+              )}
+            </td>
+          )
+        } else if (key === 'identity_match_type') {
+          scoped[key] = (item) => (
+            <td>
+              {item.identity_match_type ? (
+                <CBadge color={identityMatchTypeBadgeColors[item.identity_match_type] || 'light'}>
+                  {formatLabel(item.identity_match_type)}
+                </CBadge>
+              ) : (
+                ''
+              )}
+            </td>
+          )
+        } else if (key === 'asset_class_group') {
+          scoped[key] = (item) => (
+            <td>
+              {item.asset_class_group ? (
+                <CBadge color={assetClassGroupBadgeColors[item.asset_class_group] || 'light'}>
+                  {formatLabel(item.asset_class_group)}
+                </CBadge>
+              ) : (
+                ''
+              )}
+            </td>
+          )
+        }
+      }
+      // Handle number rendering (confidence)
+      else if (config.render === 'number') {
+        if (key === 'identity_conf') {
+          scoped[key] = (item) => <td>{formatConfidence(item.identity_conf)}</td>
+        }
+      }
+      // Handle date rendering
+      else if (config.render === 'date') {
+        scoped[key] = (item) => <td>{formatDate(item[key])}</td>
+      }
+    })
+
+    return scoped
+  }, [visibleColumns])
+
+  const fetchAssetsData = async () => {
+    setLoading(true)
+    const apiParams = {
+      limit: itemsPerPage,
+      offset: (activePage - 1) * itemsPerPage,
+    }
+
+    if (sorter && sorter.column) {
+      apiParams.sort_by = sorter.column
+      apiParams.sort_order = sorter.direction || 'asc'
+    }
+
+    // Iterate over the main columnFilter for API params
+    for (const key in columnFilter) {
+      if (columnFilter[key]) {
+        if (textInputFilterKeys.includes(key)) {
+          apiParams[`${key}_like`] = columnFilter[key]
         } else {
-            // State is 0 (cleared) or invalid
-            setSorter({});
-            setActivePage(1);
+          apiParams[key] = columnFilter[key]
         }
-    };
+      }
+    }
 
-    return (
-        <>
-            <CRow>
-                <CCol xs={12}>
-                    <CCard>
-                        <CCardHeader>
-                            <CRow className="align-items-center">
-                                <CCol xs={6} md={8} xl={9} className="text-start">
-                                    <h5>Available Assets</h5>
-                                </CCol>
-                                <CCol xs={6} md={4} xl={3} className="d-flex justify-content-end">
-                                    <CButton 
-                                        color="secondary" 
-                                        variant="outline"
-                                        onClick={() => setIsColumnSelectorVisible(true)}
-                                    >
-                                        <CIcon icon={cilSettings} className="me-1" />
-                                        Columns
-                                    </CButton>
-                                </CCol>
-                            </CRow>
-                        </CCardHeader>
-                        <CCardBody>
-                            {error && <CAlert color="danger">{error}</CAlert>}
-                            <CSmartTable
-                                items={assets}
-                                columns={columns}
-                                loading={loading}
-                                itemsPerPage={itemsPerPage}
-                                pagination={false}
-                                columnSorter={{ external: true, resetable: true }}
-                                onSorterChange={handleSorterChange}
-                                tableProps={{
-                                    striped: true,
-                                    hover: true,
-                                    responsive: true,
-                                    className: 'align-middle' 
-                                }}
+    console.log(
+      `[Assets.js] fetchAssetsData: For activePage=${activePage}, itemsPerPage=${itemsPerPage}. Requesting with API params: ${JSON.stringify(apiParams)}`,
+    )
 
-                                columnFilter
-                                columnFilterValue={liveTextInputFilters}
-                                onColumnFilterChange={setLiveTextInputFilters}
+    try {
+      const data = await getAssets(apiParams)
+      console.log(
+        `[Assets.js] fetchAssetsData: API Response for page ${activePage}: items_count=${data.items?.length}, total_items_from_api=${data.total_items}`,
+      )
 
-                                scopedColumns={scopedColumns}
-                            />
+      setAssets(data.items || [])
+      setTotalItems(data.total_items || 0)
+    } catch (err) {
+      console.error(
+        `[Assets.js] fetchAssetsData: Error fetching assets for page ${activePage}:`,
+        err,
+      )
+      setError(err.message || 'Failed to fetch assets')
+      setAssets([])
+      setTotalItems(0)
+    } finally {
+      setLoading(false)
+    }
+  }
 
-                            <CRow className="mb-3 align-items-center justify-content-center">
-                                {calculatedPages > 1 && (
-                                    <CCol xs="auto">
-                                        <CSmartPagination
-                                            activePage={activePage}
-                                            pages={calculatedPages}
-                                            onActivePageChange={setActivePage}
-                                        />
-                                    </CCol>
-                                )}
-                                <CCol xs="auto" className="me-2">
-                                    <label htmlFor="itemsPerPageSelect" className="col-form-label">Items per page:</label>
-                                </CCol>
-                                <CCol xs="auto">
-                                    <CFormSelect 
-                                        id="itemsPerPageSelect"
-                                        value={itemsPerPage}
-                                        onChange={handleItemsPerPageChange}
-                                        options={[
-                                            { label: '5', value: 5 },
-                                            { label: '10', value: 10 },
-                                            { label: '20', value: 20 },
-                                            { label: '50', value: 50 },
-                                            { label: '100', value: 100 },
-                                        ]}
-                                    />
-                                </CCol>
-                            </CRow>
-                        </CCardBody>
-                    </CCard>
+  // useEffect for debouncing live text input filters
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setColumnFilter((prevMainFilters) => {
+        const newMainFilters = { ...prevMainFilters }
+
+        textInputFilterKeys.forEach((key) => {
+          if (liveTextInputFilters[key]) {
+            newMainFilters[key] = liveTextInputFilters[key]
+          } else {
+            delete newMainFilters[key]
+          }
+        })
+        return newMainFilters
+      })
+      setActivePage(1)
+    }, 1000)
+
+    return () => {
+      clearTimeout(handler)
+    }
+  }, [liveTextInputFilters, textInputFilterKeys])
+
+  useEffect(() => {
+    setError(null)
+    console.log(
+      `[Assets.js] useEffect: Triggering fetch. Current state: activePage=${activePage}, itemsPerPage=${itemsPerPage}, sorter=${JSON.stringify(sorter)}, columnFilter=${JSON.stringify(columnFilter)}`,
+    )
+    fetchAssetsData()
+  }, [activePage, itemsPerPage, sorter, columnFilter])
+
+  const calculatedPages = totalItems > 0 ? Math.ceil(totalItems / itemsPerPage) : 1
+
+  const handleItemsPerPageChange = (event) => {
+    const newSize = parseInt(event.target.value, 10)
+    console.log(
+      `[Assets.js] handleItemsPerPageChange: newSize=${newSize}. Current itemsPerPage state is ${itemsPerPage}.`,
+    )
+    setActivePage(1)
+    setItemsPerPage(newSize)
+  }
+
+  const handleSorterChange = (sorterData) => {
+    console.log('[Assets.js] handleSorterChange:', sorterData)
+
+    // CSmartTable provides SorterValue: { column: string, state: 'asc' | 'desc' | 0 }
+    // When resetable=true, state can be 0 (null/cleared) on third click
+
+    if (!sorterData) {
+      // No sorting - clear state
+      setSorter({})
+      setActivePage(1)
+      return
+    }
+
+    // Handle single sorter (non-multiple mode)
+    if (sorterData.column && sorterData.state !== 0) {
+      setSorter({
+        column: sorterData.column,
+        direction: sorterData.state, // Map 'state' to 'direction' for API
+      })
+      setActivePage(1)
+    } else {
+      // State is 0 (cleared) or invalid
+      setSorter({})
+      setActivePage(1)
+    }
+  }
+
+  return (
+    <>
+      <CRow>
+        <CCol xs={12}>
+          <CCard>
+            <CCardHeader>
+              <CRow className="align-items-center">
+                <CCol xs={6} md={8} xl={9} className="text-start">
+                  <h5>Available Assets</h5>
                 </CCol>
-            </CRow>
+                <CCol xs={6} md={4} xl={3} className="d-flex justify-content-end">
+                  <CButton
+                    color="secondary"
+                    variant="outline"
+                    onClick={() => setIsColumnSelectorVisible(true)}
+                  >
+                    <CIcon icon={cilSettings} className="me-1" />
+                    Columns
+                  </CButton>
+                </CCol>
+              </CRow>
+            </CCardHeader>
+            <CCardBody>
+              {error && <CAlert color="danger">{error}</CAlert>}
+              <CSmartTable
+                items={assets}
+                columns={columns}
+                loading={loading}
+                itemsPerPage={itemsPerPage}
+                pagination={false}
+                columnSorter={{ external: true, resetable: true }}
+                onSorterChange={handleSorterChange}
+                tableProps={{
+                  striped: true,
+                  hover: true,
+                  responsive: true,
+                  className: 'align-middle',
+                }}
+                columnFilter
+                columnFilterValue={liveTextInputFilters}
+                onColumnFilterChange={setLiveTextInputFilters}
+                scopedColumns={scopedColumns}
+              />
 
-            <ColumnSelectorModal
-                visible={isColumnSelectorVisible}
-                onClose={() => setIsColumnSelectorVisible(false)}
-                visibleColumns={visibleColumns}
-                setVisibleColumns={setVisibleColumns}
-            />
-        </>
-    );
-};
+              <CRow className="mb-3 align-items-center justify-content-center">
+                {calculatedPages > 1 && (
+                  <CCol xs="auto">
+                    <CSmartPagination
+                      activePage={activePage}
+                      pages={calculatedPages}
+                      onActivePageChange={setActivePage}
+                    />
+                  </CCol>
+                )}
+                <CCol xs="auto" className="me-2">
+                  <label htmlFor="itemsPerPageSelect" className="col-form-label">
+                    Items per page:
+                  </label>
+                </CCol>
+                <CCol xs="auto">
+                  <CFormSelect
+                    id="itemsPerPageSelect"
+                    value={itemsPerPage}
+                    onChange={handleItemsPerPageChange}
+                    options={[
+                      { label: '5', value: 5 },
+                      { label: '10', value: 10 },
+                      { label: '20', value: 20 },
+                      { label: '50', value: 50 },
+                      { label: '100', value: 100 },
+                    ]}
+                  />
+                </CCol>
+              </CRow>
+            </CCardBody>
+          </CCard>
+        </CCol>
+      </CRow>
 
-export default Assets;
+      <ColumnSelectorModal
+        visible={isColumnSelectorVisible}
+        onClose={() => setIsColumnSelectorVisible(false)}
+        visibleColumns={visibleColumns}
+        setVisibleColumns={setVisibleColumns}
+      />
+    </>
+  )
+}
+
+export default Assets

--- a/web/src/views/assets/Assets.js
+++ b/web/src/views/assets/Assets.js
@@ -310,16 +310,8 @@ const Assets = () => {
       }
     }
 
-    console.log(
-      `[Assets.js] fetchAssetsData: For activePage=${activePage}, itemsPerPage=${itemsPerPage}. Requesting with API params: ${JSON.stringify(apiParams)}`,
-    )
-
     try {
       const data = await getAssets(apiParams)
-      console.log(
-        `[Assets.js] fetchAssetsData: API Response for page ${activePage}: items_count=${data.items?.length}, total_items_from_api=${data.total_items}`,
-      )
-
       setAssets(data.items || [])
       setTotalItems(data.total_items || 0)
     } catch (err) {
@@ -360,9 +352,6 @@ const Assets = () => {
 
   useEffect(() => {
     setError(null)
-    console.log(
-      `[Assets.js] useEffect: Triggering fetch. Current state: activePage=${activePage}, itemsPerPage=${itemsPerPage}, sorter=${JSON.stringify(sorter)}, columnFilter=${JSON.stringify(columnFilter)}`,
-    )
     fetchAssetsData()
   }, [activePage, itemsPerPage, sorter, columnFilter])
 
@@ -370,16 +359,11 @@ const Assets = () => {
 
   const handleItemsPerPageChange = (event) => {
     const newSize = parseInt(event.target.value, 10)
-    console.log(
-      `[Assets.js] handleItemsPerPageChange: newSize=${newSize}. Current itemsPerPage state is ${itemsPerPage}.`,
-    )
     setActivePage(1)
     setItemsPerPage(newSize)
   }
 
   const handleSorterChange = (sorterData) => {
-    console.log('[Assets.js] handleSorterChange:', sorterData)
-
     // CSmartTable provides SorterValue: { column: string, state: 'asc' | 'desc' | 0 }
     // When resetable=true, state can be 0 (null/cleared) on third click
 

--- a/web/src/views/assets/ColumnSelectorModal.js
+++ b/web/src/views/assets/ColumnSelectorModal.js
@@ -1,7 +1,7 @@
 /**
  * ColumnSelectorModal - Modal for selecting which columns to display in the Assets table.
  */
-import React from 'react';
+import React from 'react'
 import {
   CModal,
   CModalHeader,
@@ -11,34 +11,34 @@ import {
   CButton,
   CFormCheck,
   CRow,
-  CCol
-} from '@coreui/react-pro';
-import { ASSET_COLUMNS, getDefaultVisibleColumns, getColumnKeys } from '../../configs/assetColumns';
+  CCol,
+} from '@coreui/react-pro'
+import { ASSET_COLUMNS, getDefaultVisibleColumns, getColumnKeys } from '../../configs/assetColumns'
 
 const ColumnSelectorModal = ({ visible, onClose, visibleColumns, setVisibleColumns }) => {
-  const allColumnKeys = getColumnKeys();
+  const allColumnKeys = getColumnKeys()
 
   const handleToggleColumn = (columnKey) => {
     setVisibleColumns((prev) => {
       if (prev.includes(columnKey)) {
-        return prev.filter((key) => key !== columnKey);
+        return prev.filter((key) => key !== columnKey)
       } else {
-        return [...prev, columnKey];
+        return [...prev, columnKey]
       }
-    });
-  };
+    })
+  }
 
   const handleSelectAll = () => {
-    setVisibleColumns(allColumnKeys);
-  };
+    setVisibleColumns(allColumnKeys)
+  }
 
   const handleDeselectAll = () => {
-    setVisibleColumns([]);
-  };
+    setVisibleColumns([])
+  }
 
   const handleResetToDefaults = () => {
-    setVisibleColumns(getDefaultVisibleColumns());
-  };
+    setVisibleColumns(getDefaultVisibleColumns())
+  }
 
   return (
     <CModal visible={visible} onClose={onClose} size="lg">
@@ -61,7 +61,7 @@ const ColumnSelectorModal = ({ visible, onClose, visibleColumns, setVisibleColum
         </CRow>
         <CRow>
           {allColumnKeys.map((columnKey) => {
-            const columnConfig = ASSET_COLUMNS[columnKey];
+            const columnConfig = ASSET_COLUMNS[columnKey]
             return (
               <CCol xs={6} md={4} lg={3} key={columnKey} className="mb-2">
                 <CFormCheck
@@ -71,7 +71,7 @@ const ColumnSelectorModal = ({ visible, onClose, visibleColumns, setVisibleColum
                   onChange={() => handleToggleColumn(columnKey)}
                 />
               </CCol>
-            );
+            )
           })}
         </CRow>
       </CModalBody>
@@ -81,7 +81,7 @@ const ColumnSelectorModal = ({ visible, onClose, visibleColumns, setVisibleColum
         </CButton>
       </CModalFooter>
     </CModal>
-  );
-};
+  )
+}
 
-export default ColumnSelectorModal;
+export default ColumnSelectorModal

--- a/web/src/views/dashboard/Dashboard.js
+++ b/web/src/views/dashboard/Dashboard.js
@@ -87,7 +87,20 @@ const Dashboard = () => {
   ]
 
   const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July']
-  const allMonths = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+  const allMonths = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ]
 
   return (
     <>
@@ -292,9 +305,7 @@ const Dashboard = () => {
                   <CRow>
                     <CCol xs={6}>
                       <div className="border-start border-start-4 border-start-info py-1 px-3 mb-3">
-                        <div className="text-body-secondary text-truncate small">
-                          New Clients
-                        </div>
+                        <div className="text-body-secondary text-truncate small">New Clients</div>
                         <div className="fs-5 fw-semibold">9,123</div>
                       </div>
                     </CCol>
@@ -324,17 +335,13 @@ const Dashboard = () => {
                   <CRow>
                     <CCol xs={6}>
                       <div className="border-start border-start-4 border-start-warning py-1 px-3 mb-3">
-                        <div className="text-body-secondary text-truncate small">
-                          Pageviews
-                        </div>
+                        <div className="text-body-secondary text-truncate small">Pageviews</div>
                         <div className="fs-5 fw-semibold">78,623</div>
                       </div>
                     </CCol>
                     <CCol xs={6}>
                       <div className="border-start border-start-4 border-start-success py-1 px-3 mb-3">
-                        <div className="text-body-secondary text-truncate small">
-                          Organic
-                        </div>
+                        <div className="text-body-secondary text-truncate small">Organic</div>
                         <div className="fs-5 fw-semibold">49,123</div>
                       </div>
                     </CCol>

--- a/web/src/views/data-explorer/CandlestickChart.js
+++ b/web/src/views/data-explorer/CandlestickChart.js
@@ -3,12 +3,7 @@ import PropTypes from 'prop-types'
 import { createChart } from 'lightweight-charts'
 import { getOHLCData } from '../services/datahub_api'
 import CIcon from '@coreui/icons-react'
-import {
-  cilReload,
-  cilFullscreen,
-  cilChevronLeft,
-  cilChevronRight,
-} from '@coreui/icons'
+import { cilReload, cilFullscreen, cilChevronLeft, cilChevronRight } from '@coreui/icons'
 
 const CandlestickChart = ({ provider, symbol, dataType, interval, limit = 5000, onDataChange }) => {
   const chartContainerRef = useRef(null)
@@ -70,37 +65,40 @@ const CandlestickChart = ({ provider, symbol, dataType, interval, limit = 5000, 
   }, [])
 
   // Theme-aware color schemes
-  const chartColors = useMemo(() => isDarkMode
-    ? {
-        background: '#000000',
-        text: '#ffffff',
-        grid: '#1a1a1a',
-        border: '#2a2e39',
-        crosshairLine: '#758696',
-        crosshairLabel: '#1e1e1e',
-        buttonBg: 'rgba(42, 46, 57, 0.9)',
-        buttonHover: 'rgba(58, 64, 77, 0.9)',
-        overlayBg: 'rgba(0, 0, 0, 0.8)',
-      }
-    : {
-        background: '#ffffff',
-        text: '#131722',
-        grid: '#e1e3eb',
-        border: '#d1d4dc',
-        crosshairLine: '#758696',
-        crosshairLabel: '#f0f3fa',
-        buttonBg: 'rgba(240, 243, 250, 0.9)',
-        buttonHover: 'rgba(220, 224, 235, 0.9)',
-        overlayBg: 'rgba(255, 255, 255, 0.9)',
-      }
-  , [isDarkMode])
+  const chartColors = useMemo(
+    () =>
+      isDarkMode
+        ? {
+            background: '#000000',
+            text: '#ffffff',
+            grid: '#1a1a1a',
+            border: '#2a2e39',
+            crosshairLine: '#758696',
+            crosshairLabel: '#1e1e1e',
+            buttonBg: 'rgba(42, 46, 57, 0.9)',
+            buttonHover: 'rgba(58, 64, 77, 0.9)',
+            overlayBg: 'rgba(0, 0, 0, 0.8)',
+          }
+        : {
+            background: '#ffffff',
+            text: '#131722',
+            grid: '#e1e3eb',
+            border: '#d1d4dc',
+            crosshairLine: '#758696',
+            crosshairLabel: '#f0f3fa',
+            buttonBg: 'rgba(240, 243, 250, 0.9)',
+            buttonHover: 'rgba(220, 224, 235, 0.9)',
+            overlayBg: 'rgba(255, 255, 255, 0.9)',
+          },
+    [isDarkMode],
+  )
 
   // Calculate chart height based on container width with responsive aspect ratios
   const calculateChartHeight = (containerWidth) => {
     let aspectRatio
     let minHeight
     let maxHeight
-    
+
     if (containerWidth >= 992) {
       // Desktop (lg, xl)
       aspectRatio = 2.5
@@ -117,7 +115,7 @@ const CandlestickChart = ({ provider, symbol, dataType, interval, limit = 5000, 
       minHeight = 300
       maxHeight = 400
     }
-    
+
     const calculatedHeight = containerWidth / aspectRatio
     return Math.max(minHeight, Math.min(maxHeight, calculatedHeight))
   }
@@ -125,15 +123,15 @@ const CandlestickChart = ({ provider, symbol, dataType, interval, limit = 5000, 
   // Update chart dimensions based on container size
   const updateChartDimensions = () => {
     if (!chartContainerRef.current) return { width: 0, height: 500 }
-    
+
     const containerWidth = chartContainerRef.current.clientWidth
     const calculatedHeight = calculateChartHeight(containerWidth)
-    
+
     const dimensions = {
       width: containerWidth,
       height: calculatedHeight,
     }
-    
+
     setChartDimensions(dimensions)
     return dimensions
   }
@@ -191,13 +189,13 @@ const CandlestickChart = ({ provider, symbol, dataType, interval, limit = 5000, 
             top: 0.1,
             bottom: 0.1,
           },
-          entireRangeOnly: true,  // Prevent scrolling beyond data range (min/max)
+          entireRangeOnly: true, // Prevent scrolling beyond data range (min/max)
         },
         timeScale: {
           borderColor: chartColors.border,
           timeVisible: true,
           secondsVisible: false,
-          fixLeftEdge: true,  // Prevent scrolling past the first (oldest) bar
+          fixLeftEdge: true, // Prevent scrolling past the first (oldest) bar
           fixRightEdge: true, // Prevent scrolling past the last (newest) bar
         },
       })
@@ -247,7 +245,7 @@ const CandlestickChart = ({ provider, symbol, dataType, interval, limit = 5000, 
         if (resizeTimeoutRef.current) {
           clearTimeout(resizeTimeoutRef.current)
         }
-        
+
         // Debounce resize events (150ms)
         resizeTimeoutRef.current = setTimeout(() => {
           if (chartContainerRef.current && chart) {
@@ -376,7 +374,7 @@ const CandlestickChart = ({ provider, symbol, dataType, interval, limit = 5000, 
           // Store full data (with volume) for download
           const fullData = [...response.bars]
           setAllData(fullData)
-          
+
           // Notify parent component of data change
           if (onDataChange && !cancelledRef.current) {
             onDataChange(fullData)
@@ -387,7 +385,7 @@ const CandlestickChart = ({ provider, symbol, dataType, interval, limit = 5000, 
           // Chart expects: { time: number, open, high, low, close }
           // Sort by time ascending (data comes desc from API, chart needs asc)
           const chartData = response.bars
-            .map(bar => ({
+            .map((bar) => ({
               time: bar.time,
               open: bar.open,
               high: bar.high,
@@ -398,7 +396,7 @@ const CandlestickChart = ({ provider, symbol, dataType, interval, limit = 5000, 
 
           // Transform volume data with color coding
           const volumeData = response.bars
-            .map(bar => ({
+            .map((bar) => ({
               time: bar.time,
               value: bar.volume,
               color: bar.close >= bar.open ? '#26a69a' : '#ef5350', // Green for up, red for down
@@ -407,15 +405,15 @@ const CandlestickChart = ({ provider, symbol, dataType, interval, limit = 5000, 
 
           if (candlestickSeriesRef.current && !cancelledRef.current) {
             candlestickSeriesRef.current.setData(chartData)
-            
+
             // Set volume data
             if (volumeSeriesRef.current) {
               volumeSeriesRef.current.setData(volumeData)
             }
-            
+
             // Store chart data for button functions
             setChartData(chartData)
-            
+
             // Set initial visible range to show only the most recent 500 bars (1/10th of total)
             const visibleBarCount = 500
             if (chartData.length > visibleBarCount && chartRef.current) {
@@ -424,14 +422,14 @@ const CandlestickChart = ({ provider, symbol, dataType, interval, limit = 5000, 
               const visibleStartIndex = chartData.length - visibleBarCount
               const visibleStartTime = chartData[visibleStartIndex].time
               const visibleEndTime = chartData[chartData.length - 1].time
-              
+
               // Store initial view range for Reset View button
               const initialRange = {
                 from: visibleStartTime,
                 to: visibleEndTime,
               }
               setInitialViewRange(initialRange)
-              
+
               // Set visible range to show only the most recent bars
               timeScale.setVisibleRange(initialRange)
             } else {
@@ -766,4 +764,3 @@ CandlestickChart.defaultProps = {
 }
 
 export default CandlestickChart
-

--- a/web/src/views/data-explorer/DataExplorer.js
+++ b/web/src/views/data-explorer/DataExplorer.js
@@ -19,13 +19,13 @@ import { INTERVALS } from '../../enums'
 
 const DataExplorer = () => {
   const [activeKey, setActiveKey] = useState(1)
-  
+
   // Search state
   const [searchQuery, setSearchQuery] = useState('')
   const [searchResults, setSearchResults] = useState([])
   const [isSearching, setIsSearching] = useState(false)
   const [searchError, setSearchError] = useState(null)
-  
+
   // Selection state
   const [selectedSymbol, setSelectedSymbol] = useState(null)
   const [selectedProvider, setSelectedProvider] = useState('')
@@ -33,7 +33,7 @@ const DataExplorer = () => {
   const [selectedDataType, setSelectedDataType] = useState('')
   const [selectedInterval, setSelectedInterval] = useState('')
   const [availableIntervals, setAvailableIntervals] = useState([])
-  
+
   // Data state for download functionality
   const [currentData, setCurrentData] = useState([])
 
@@ -53,7 +53,7 @@ const DataExplorer = () => {
 
     setIsSearching(true)
     setSearchError(null)
-    
+
     // Clear previous selection when performing new search
     // This prevents stale object references from breaking the select dropdown
     setSelectedSymbol(null)
@@ -98,7 +98,7 @@ const DataExplorer = () => {
       const canonicalIntervals = symbolIntervals.filter((iv) => INTERVALS.includes(iv))
       const intervalsToUse = canonicalIntervals.length > 0 ? canonicalIntervals : symbolIntervals
       setAvailableIntervals(intervalsToUse)
-      
+
       // Auto-select data type if only one is available
       if (symbol.has_historical && !symbol.has_live) {
         setSelectedDataType('historical')
@@ -108,7 +108,7 @@ const DataExplorer = () => {
         // Default to historical if both available
         setSelectedDataType('historical')
       }
-      
+
       // Auto-select first interval if available
       if (intervalsToUse && intervalsToUse.length > 0) {
         setSelectedInterval(intervalsToUse[0])
@@ -122,7 +122,7 @@ const DataExplorer = () => {
   const handleDataTypeChange = (e) => {
     setSelectedDataType(e.target.value)
     setSelectedInterval('')
-    
+
     // Update available intervals based on selected symbol and data type
     if (selectedSymbol) {
       const symbolIntervals = selectedSymbol.available_intervals || []
@@ -150,7 +150,13 @@ const DataExplorer = () => {
 
   // Handle download click
   const handleDownload = () => {
-    if (currentData && currentData.length > 0 && selectedSymbol && selectedDataType && selectedInterval) {
+    if (
+      currentData &&
+      currentData.length > 0 &&
+      selectedSymbol &&
+      selectedDataType &&
+      selectedInterval
+    ) {
       // Convert chart data format to OHLC format if needed
       // Chart data has time, open, high, low, close (no volume in chartData)
       // We need to get the full data from the API response
@@ -160,7 +166,8 @@ const DataExplorer = () => {
   }
 
   // Determine if download button should be enabled
-  const canDownload = selectedSymbol && selectedDataType && selectedInterval && currentData && currentData.length > 0
+  const canDownload =
+    selectedSymbol && selectedDataType && selectedInterval && currentData && currentData.length > 0
 
   return (
     <CRow>
@@ -230,8 +237,8 @@ const DataExplorer = () => {
                 {selectedSymbol && (
                   <div className="mt-2 pt-2 border-top">
                     <small className="text-muted">
-                      <strong>Common:</strong> {selectedSymbol.common_symbol} | 
-                      <strong> Provider:</strong> {selectedSymbol.provider} | 
+                      <strong>Common:</strong> {selectedSymbol.common_symbol} |
+                      <strong> Provider:</strong> {selectedSymbol.provider} |
                       <strong> Symbol:</strong> {selectedSymbol.provider_symbol}
                     </small>
                   </div>
@@ -273,8 +280,8 @@ const DataExplorer = () => {
                 {selectedSymbol && (
                   <div className="mt-2 pt-2 border-top">
                     <small className="text-muted">
-                      <strong>Common:</strong> {selectedSymbol.common_symbol} | 
-                      <strong> Provider:</strong> {selectedSymbol.provider} | 
+                      <strong>Common:</strong> {selectedSymbol.common_symbol} |
+                      <strong> Provider:</strong> {selectedSymbol.provider} |
                       <strong> Symbol:</strong> {selectedSymbol.provider_symbol}
                     </small>
                   </div>
@@ -289,4 +296,3 @@ const DataExplorer = () => {
 }
 
 export default DataExplorer
-

--- a/web/src/views/data-explorer/DataExplorerToolbar.js
+++ b/web/src/views/data-explorer/DataExplorerToolbar.js
@@ -1,21 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {
-  CFormInput,
-  CFormSelect,
-  CButton,
-  CSpinner,
-  CInputGroup,
-} from '@coreui/react-pro'
+import { CFormInput, CFormSelect, CButton, CSpinner, CInputGroup } from '@coreui/react-pro'
 import CIcon from '@coreui/icons-react'
 import { cilMagnifyingGlass, cilCloudDownload } from '@coreui/icons'
 
 /**
  * DataExplorerToolbar Component
- * 
+ *
  * Reusable toolbar component for Data Explorer views (Chart and Table).
  * Uses idPrefix to generate unique accessibility IDs for each view instance.
- * 
+ *
  * @param {string} idPrefix - Prefix for generating unique IDs (e.g., 'chart' or 'table')
  * @param {string} searchQuery - Current search query value
  * @param {function} setSearchQuery - Handler to update search query
@@ -77,24 +71,23 @@ const DataExplorerToolbar = ({
             color="primary"
             onClick={handleSearch}
             disabled={isSearching}
-            aria-label={isSearching ? "Searching symbols" : "Search for symbols"}
+            aria-label={isSearching ? 'Searching symbols' : 'Search for symbols'}
             title="Search symbols"
           >
-            {isSearching ? <CSpinner size="sm" aria-hidden="true" /> : <CIcon icon={cilMagnifyingGlass} />}
+            {isSearching ? (
+              <CSpinner size="sm" aria-hidden="true" />
+            ) : (
+              <CIcon icon={cilMagnifyingGlass} />
+            )}
           </CButton>
         </CInputGroup>
         {searchError && (
-          <div 
-            id={errorId}
-            className="text-danger small mt-1" 
-            role="alert"
-            aria-live="polite"
-          >
+          <div id={errorId} className="text-danger small mt-1" role="alert" aria-live="polite">
             {searchError}
           </div>
         )}
       </div>
-      
+
       {/* Symbol Select */}
       <div className="flex-grow-1" style={{ minWidth: '280px' }}>
         <CFormSelect
@@ -107,12 +100,18 @@ const DataExplorerToolbar = ({
           {searchResults.map((symbol, index) => (
             <option key={index} value={index}>
               {symbol.common_symbol} ({symbol.provider}/{symbol.provider_symbol})
-              {symbol.has_historical && symbol.has_live ? ' [H+L]' : symbol.has_historical ? ' [H]' : symbol.has_live ? ' [L]' : ''}
+              {symbol.has_historical && symbol.has_live
+                ? ' [H+L]'
+                : symbol.has_historical
+                  ? ' [H]'
+                  : symbol.has_live
+                    ? ' [L]'
+                    : ''}
             </option>
           ))}
         </CFormSelect>
       </div>
-      
+
       {/* Data Type - only show when symbol selected */}
       {selectedSymbol && (
         <div style={{ minWidth: '140px' }}>
@@ -123,12 +122,8 @@ const DataExplorerToolbar = ({
             aria-describedby={!selectedDataType ? dataTypeHelpId : undefined}
           >
             <option value="">Type...</option>
-            {selectedSymbol.has_historical && (
-              <option value="historical">Historical</option>
-            )}
-            {selectedSymbol.has_live && (
-              <option value="live">Live</option>
-            )}
+            {selectedSymbol.has_historical && <option value="historical">Historical</option>}
+            {selectedSymbol.has_live && <option value="live">Live</option>}
           </CFormSelect>
           {!selectedDataType && (
             <div id={dataTypeHelpId} className="sr-only">
@@ -137,7 +132,7 @@ const DataExplorerToolbar = ({
           )}
         </div>
       )}
-      
+
       {/* Interval - only show when data type selected */}
       {selectedDataType && (
         <div style={{ minWidth: '120px' }}>
@@ -156,13 +151,18 @@ const DataExplorerToolbar = ({
             ))}
           </CFormSelect>
           {availableIntervals.length === 0 && (
-            <div id={intervalHelpId} className="text-muted small mt-1" role="status" aria-live="polite">
+            <div
+              id={intervalHelpId}
+              className="text-muted small mt-1"
+              role="status"
+              aria-live="polite"
+            >
               No intervals available
             </div>
           )}
         </div>
       )}
-      
+
       {/* Download Button - progressive disclosure */}
       {selectedSymbol && selectedDataType && selectedInterval && (
         <div>
@@ -172,8 +172,8 @@ const DataExplorerToolbar = ({
             size="sm"
             onClick={handleDownload}
             disabled={!canDownload}
-            title={canDownload ? "Download data as CSV" : "Select data to download"}
-            aria-label={canDownload ? "Download data as CSV file" : "Select data to download"}
+            title={canDownload ? 'Download data as CSV' : 'Select data to download'}
+            aria-label={canDownload ? 'Download data as CSV file' : 'Select data to download'}
           >
             <CIcon icon={cilCloudDownload} size="sm" />
           </CButton>
@@ -209,4 +209,3 @@ DataExplorerToolbar.defaultProps = {
 }
 
 export default DataExplorerToolbar
-

--- a/web/src/views/data-explorer/OHLCTable.js
+++ b/web/src/views/data-explorer/OHLCTable.js
@@ -47,10 +47,12 @@ const OHLCTable = ({ provider, symbol, dataType, interval, limit = 5000, onDataC
 
   // Format volume
   const formatVolume = (volume) => {
-    return typeof volume === 'number' ? volume.toLocaleString('en-US', {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }) : volume
+    return typeof volume === 'number'
+      ? volume.toLocaleString('en-US', {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        })
+      : volume
   }
 
   // Determine if price went up (green) or down (red)
@@ -138,7 +140,7 @@ const OHLCTable = ({ provider, symbol, dataType, interval, limit = 5000, onDataC
 
   // Handle sort toggle
   const handleSortToggle = () => {
-    setSortDirection(prev => prev === 'desc' ? 'asc' : 'desc')
+    setSortDirection((prev) => (prev === 'desc' ? 'asc' : 'desc'))
     setCurrentPage(1) // Reset to first page when sorting changes
   }
 
@@ -179,7 +181,8 @@ const OHLCTable = ({ provider, symbol, dataType, interval, limit = 5000, onDataC
             </CFormSelect>
           </div>
           <div className="small text-muted">
-            Showing {startIndex + 1}-{Math.min(endIndex, sortedData.length)} of {sortedData.length} records
+            Showing {startIndex + 1}-{Math.min(endIndex, sortedData.length)} of {sortedData.length}{' '}
+            records
           </div>
         </div>
       )}
@@ -235,7 +238,12 @@ const OHLCTable = ({ provider, symbol, dataType, interval, limit = 5000, onDataC
             ) : (
               currentPageData.map((bar, index) => {
                 const priceChange = getPriceChange(bar.open, bar.close)
-                const textColor = priceChange === 'up' ? 'text-success' : priceChange === 'down' ? 'text-danger' : 'text-muted'
+                const textColor =
+                  priceChange === 'up'
+                    ? 'text-success'
+                    : priceChange === 'down'
+                      ? 'text-danger'
+                      : 'text-muted'
 
                 return (
                   <CTableRow key={`${bar.time}-${index}`}>
@@ -287,4 +295,3 @@ OHLCTable.defaultProps = {
 }
 
 export default OHLCTable
-

--- a/web/src/views/indices/ConfirmModal.js
+++ b/web/src/views/indices/ConfirmModal.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 import {
   CModal,
   CModalHeader,
@@ -6,9 +6,9 @@ import {
   CModalBody,
   CModalFooter,
   CButton,
-} from '@coreui/react-pro';
-import CIcon from '@coreui/icons-react';
-import { cilWarning } from '@coreui/icons';
+} from '@coreui/react-pro'
+import CIcon from '@coreui/icons-react'
+import { cilWarning } from '@coreui/icons'
 
 const ConfirmModal = ({
   visible,
@@ -38,7 +38,7 @@ const ConfirmModal = ({
         </CButton>
       </CModalFooter>
     </CModal>
-  );
-};
+  )
+}
 
-export default ConfirmModal;
+export default ConfirmModal

--- a/web/src/views/indices/CreateIndexModal.js
+++ b/web/src/views/indices/CreateIndexModal.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react'
 import {
   CModal,
   CModalHeader,
@@ -12,80 +12,76 @@ import {
   CFormTextarea,
   CSpinner,
   CAlert,
-} from '@coreui/react-pro';
-import CIcon from '@coreui/icons-react';
-import { cilWarning } from '@coreui/icons';
+} from '@coreui/react-pro'
+import CIcon from '@coreui/icons-react'
+import { cilWarning } from '@coreui/icons'
 
-import { createUserIndex } from '../services/registry_api';
+import { createUserIndex } from '../services/registry_api'
 
 const CreateIndexModal = ({ visible, onClose, onSuccess, pushToast }) => {
-  const [name, setName] = useState('');
-  const [description, setDescription] = useState('');
-  const [isSaving, setIsSaving] = useState(false);
-  const [saveError, setSaveError] = useState(null);
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState(null)
 
   // Reset form when modal opens
   useEffect(() => {
     if (visible) {
-      setName('');
-      setDescription('');
-      setSaveError(null);
+      setName('')
+      setDescription('')
+      setSaveError(null)
     }
-  }, [visible]);
+  }, [visible])
 
   const handleSubmit = async (e) => {
-    e.preventDefault();
+    e.preventDefault()
 
     // Validate name
-    const trimmedName = name.trim();
+    const trimmedName = name.trim()
     if (!trimmedName) {
-      setSaveError('Index name is required.');
-      return;
+      setSaveError('Index name is required.')
+      return
     }
 
-    setIsSaving(true);
-    setSaveError(null);
+    setIsSaving(true)
+    setSaveError(null)
 
     try {
-      const data = { name: trimmedName };
+      const data = { name: trimmedName }
       if (description.trim()) {
-        data.description = description.trim();
+        data.description = description.trim()
       }
 
-      await createUserIndex(data);
+      await createUserIndex(data)
 
       if (pushToast) {
         pushToast({
           title: 'Index Created',
           body: `Index "${trimmedName}" has been created successfully.`,
           color: 'success',
-        });
+        })
       }
 
       if (onSuccess) {
-        onSuccess();
+        onSuccess()
       }
 
-      onClose();
+      onClose()
     } catch (err) {
-      setSaveError(err.message || 'Failed to create index.');
+      setSaveError(err.message || 'Failed to create index.')
     } finally {
-      setIsSaving(false);
+      setIsSaving(false)
     }
-  };
+  }
 
   const handleClose = () => {
     if (!isSaving) {
-      onClose();
+      onClose()
     }
-  };
+  }
 
   return (
-    <CModal
-      visible={visible}
-      onClose={handleClose}
-      backdrop="static"
-    >
+    <CModal visible={visible} onClose={handleClose} backdrop="static">
       <CModalHeader onClose={handleClose}>
         <CModalTitle>Create New Index</CModalTitle>
       </CModalHeader>
@@ -113,9 +109,7 @@ const CreateIndexModal = ({ visible, onClose, onSuccess, pushToast }) => {
               maxLength={100}
               required
             />
-            <div className="form-text">
-              A unique name for your index (max 100 characters).
-            </div>
+            <div className="form-text">A unique name for your index (max 100 characters).</div>
           </div>
 
           <div className="mb-3">
@@ -132,18 +126,10 @@ const CreateIndexModal = ({ visible, onClose, onSuccess, pushToast }) => {
         </CModalBody>
 
         <CModalFooter>
-          <CButton
-            color="secondary"
-            onClick={handleClose}
-            disabled={isSaving}
-          >
+          <CButton color="secondary" onClick={handleClose} disabled={isSaving}>
             Cancel
           </CButton>
-          <CButton
-            color="primary"
-            type="submit"
-            disabled={isSaving || !name.trim()}
-          >
+          <CButton color="primary" type="submit" disabled={isSaving || !name.trim()}>
             {isSaving ? (
               <>
                 <CSpinner size="sm" className="me-1" />
@@ -156,7 +142,7 @@ const CreateIndexModal = ({ visible, onClose, onSuccess, pushToast }) => {
         </CModalFooter>
       </CForm>
     </CModal>
-  );
-};
+  )
+}
 
-export default CreateIndexModal;
+export default CreateIndexModal

--- a/web/src/views/indices/DeleteIndexModal.js
+++ b/web/src/views/indices/DeleteIndexModal.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState } from 'react'
 import {
   CModal,
   CModalHeader,
@@ -8,58 +8,54 @@ import {
   CButton,
   CSpinner,
   CAlert,
-} from '@coreui/react-pro';
-import CIcon from '@coreui/icons-react';
-import { cilWarning, cilTrash } from '@coreui/icons';
+} from '@coreui/react-pro'
+import CIcon from '@coreui/icons-react'
+import { cilWarning, cilTrash } from '@coreui/icons'
 
-import { deleteUserIndex } from '../services/registry_api';
+import { deleteUserIndex } from '../services/registry_api'
 
 const DeleteIndexModal = ({ visible, onClose, onSuccess, indexName, pushToast }) => {
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [deleteError, setDeleteError] = useState(null);
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState(null)
 
   const handleDelete = async () => {
-    if (!indexName) return;
+    if (!indexName) return
 
-    setIsDeleting(true);
-    setDeleteError(null);
+    setIsDeleting(true)
+    setDeleteError(null)
 
     try {
-      await deleteUserIndex(indexName);
+      await deleteUserIndex(indexName)
 
       if (pushToast) {
         pushToast({
           title: 'Index Deleted',
           body: `Index "${indexName}" has been deleted.`,
           color: 'success',
-        });
+        })
       }
 
       if (onSuccess) {
-        onSuccess();
+        onSuccess()
       }
 
-      onClose();
+      onClose()
     } catch (err) {
-      setDeleteError(err.message || 'Failed to delete index.');
+      setDeleteError(err.message || 'Failed to delete index.')
     } finally {
-      setIsDeleting(false);
+      setIsDeleting(false)
     }
-  };
+  }
 
   const handleClose = () => {
     if (!isDeleting) {
-      setDeleteError(null);
-      onClose();
+      setDeleteError(null)
+      onClose()
     }
-  };
+  }
 
   return (
-    <CModal
-      visible={visible}
-      onClose={handleClose}
-      backdrop="static"
-    >
+    <CModal visible={visible} onClose={handleClose} backdrop="static">
       <CModalHeader onClose={handleClose}>
         <CModalTitle className="text-danger">
           <CIcon icon={cilTrash} className="me-2" />
@@ -76,8 +72,7 @@ const DeleteIndexModal = ({ visible, onClose, onSuccess, indexName, pushToast })
         )}
 
         <p>
-          Are you sure you want to delete the index{' '}
-          <strong>&quot;{indexName}&quot;</strong>?
+          Are you sure you want to delete the index <strong>&quot;{indexName}&quot;</strong>?
         </p>
         <p className="text-danger mb-0">
           <CIcon icon={cilWarning} className="me-1" />
@@ -86,18 +81,10 @@ const DeleteIndexModal = ({ visible, onClose, onSuccess, indexName, pushToast })
       </CModalBody>
 
       <CModalFooter>
-        <CButton
-          color="secondary"
-          onClick={handleClose}
-          disabled={isDeleting}
-        >
+        <CButton color="secondary" onClick={handleClose} disabled={isDeleting}>
           Cancel
         </CButton>
-        <CButton
-          color="danger"
-          onClick={handleDelete}
-          disabled={isDeleting}
-        >
+        <CButton color="danger" onClick={handleDelete} disabled={isDeleting}>
           {isDeleting ? (
             <>
               <CSpinner size="sm" className="me-1" />
@@ -112,7 +99,7 @@ const DeleteIndexModal = ({ visible, onClose, onSuccess, indexName, pushToast })
         </CButton>
       </CModalFooter>
     </CModal>
-  );
-};
+  )
+}
 
-export default DeleteIndexModal;
+export default DeleteIndexModal

--- a/web/src/views/indices/EditableMembersTable.js
+++ b/web/src/views/indices/EditableMembersTable.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useRef } from 'react'
 import {
   CTable,
   CTableHead,
@@ -9,41 +9,41 @@ import {
   CButton,
   CFormInput,
   CAlert,
-} from '@coreui/react-pro';
-import CIcon from '@coreui/icons-react';
-import { cilTrash, cilPlus, cilWarning } from '@coreui/icons';
-import AsyncSelect from 'react-select/async';
-import { getCommonSymbols } from '../services/registry_api';
-import { formatWeightForInput } from '../../utils/formatting';
+} from '@coreui/react-pro'
+import CIcon from '@coreui/icons-react'
+import { cilTrash, cilPlus, cilWarning } from '@coreui/icons'
+import AsyncSelect from 'react-select/async'
+import { getCommonSymbols } from '../services/registry_api'
+import { formatWeightForInput } from '../../utils/formatting'
 
 const EditableMembersTable = ({ members, onChange, disabled }) => {
   // Counter for generating unique row IDs (scoped to component instance)
-  const rowIdCounterRef = useRef(0);
-  const generateId = useCallback(() => `new_${++rowIdCounterRef.current}`, []);
+  const rowIdCounterRef = useRef(0)
+  const generateId = useCallback(() => `new_${++rowIdCounterRef.current}`, [])
   // Load common symbol options for AsyncSelect
   const loadSymbolOptions = useCallback(async (inputValue, callback) => {
     if (inputValue.length < 1) {
-      callback([]);
-      return;
+      callback([])
+      return
     }
 
     try {
       const data = await getCommonSymbols({
         common_symbol_like: inputValue,
         limit: 50,
-      });
+      })
 
       const options = (data.items || []).map((item) => ({
         value: item.common_symbol,
         label: item.common_symbol,
-      }));
+      }))
 
-      callback(options);
+      callback(options)
     } catch (error) {
-      console.error('Error loading symbol options:', error);
-      callback([]);
+      console.error('Error loading symbol options:', error)
+      callback([])
     }
-  }, []);
+  }, [])
 
   // Handle symbol change for a row
   const handleSymbolChange = (rowId, selectedOption) => {
@@ -54,25 +54,23 @@ const EditableMembersTable = ({ members, onChange, disabled }) => {
             common_symbol: selectedOption?.value || null,
             selectOption: selectedOption,
           }
-        : m
-    );
-    onChange(updated);
-  };
+        : m,
+    )
+    onChange(updated)
+  }
 
   // Handle weight change for a row (input is percentage, store as decimal)
   const handleWeightChange = (rowId, value) => {
-    const numValue = value === '' ? null : parseFloat(value) / 100;
-    const updated = members.map((m) =>
-      m.id === rowId ? { ...m, weight: numValue } : m
-    );
-    onChange(updated);
-  };
+    const numValue = value === '' ? null : parseFloat(value) / 100
+    const updated = members.map((m) => (m.id === rowId ? { ...m, weight: numValue } : m))
+    onChange(updated)
+  }
 
   // Handle delete row
   const handleDeleteRow = (rowId) => {
-    const updated = members.filter((m) => m.id !== rowId);
-    onChange(updated);
-  };
+    const updated = members.filter((m) => m.id !== rowId)
+    onChange(updated)
+  }
 
   // Handle add new row
   const handleAddRow = () => {
@@ -82,35 +80,31 @@ const EditableMembersTable = ({ members, onChange, disabled }) => {
       weight: null,
       isNew: true,
       selectOption: null,
-    };
-    onChange([...members, newRow]);
-  };
+    }
+    onChange([...members, newRow])
+  }
 
   // Calculate validation warnings
   const getValidationWarnings = () => {
-    const warnings = [];
+    const warnings = []
 
     // Check for duplicate symbols
-    const symbols = members
-      .map((m) => m.common_symbol)
-      .filter((s) => s !== null);
-    const duplicates = symbols.filter(
-      (s, i) => symbols.indexOf(s) !== i
-    );
+    const symbols = members.map((m) => m.common_symbol).filter((s) => s !== null)
+    const duplicates = symbols.filter((s, i) => symbols.indexOf(s) !== i)
     if (duplicates.length > 0) {
-      warnings.push(`Duplicate symbols: ${[...new Set(duplicates)].join(', ')}`);
+      warnings.push(`Duplicate symbols: ${[...new Set(duplicates)].join(', ')}`)
     }
 
     // Check for empty symbols in new rows
-    const emptyNewRows = members.filter((m) => m.isNew && !m.common_symbol);
+    const emptyNewRows = members.filter((m) => m.isNew && !m.common_symbol)
     if (emptyNewRows.length > 0) {
-      warnings.push(`${emptyNewRows.length} row(s) have no symbol selected`);
+      warnings.push(`${emptyNewRows.length} row(s) have no symbol selected`)
     }
 
-    return warnings;
-  };
+    return warnings
+  }
 
-  const warnings = getValidationWarnings();
+  const warnings = getValidationWarnings()
 
   return (
     <div>
@@ -214,7 +208,7 @@ const EditableMembersTable = ({ members, onChange, disabled }) => {
         </CButton>
       </div>
     </div>
-  );
-};
+  )
+}
 
-export default EditableMembersTable;
+export default EditableMembersTable

--- a/web/src/views/indices/IndexDetailModal.js
+++ b/web/src/views/indices/IndexDetailModal.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import {
   CModal,
   CModalHeader,
@@ -22,32 +22,48 @@ import {
   CTableDataCell,
   CFormInput,
   CFormLabel,
-} from '@coreui/react-pro';
-import CIcon from '@coreui/icons-react';
-import { cilReload, cilWarning, cilPencil, cilTrash, cilHistory } from '@coreui/icons';
-import { CChartPie } from '@coreui/react-chartjs';
+} from '@coreui/react-pro'
+import CIcon from '@coreui/icons-react'
+import { cilReload, cilWarning, cilPencil, cilTrash, cilHistory } from '@coreui/icons'
+import { CChartPie } from '@coreui/react-chartjs'
 
-import CommonSymbolDetailModal from '../mappings/CommonSymbolDetailModal';
-import EditableMembersTable from './EditableMembersTable';
-import DeleteIndexModal from './DeleteIndexModal';
-import SaveChangesModal from './SaveChangesModal';
-import ConfirmModal from './ConfirmModal';
+import CommonSymbolDetailModal from '../mappings/CommonSymbolDetailModal'
+import EditableMembersTable from './EditableMembersTable'
+import DeleteIndexModal from './DeleteIndexModal'
+import SaveChangesModal from './SaveChangesModal'
+import ConfirmModal from './ConfirmModal'
 import {
   getIndexDetail,
   getIndexMembers,
   getIndexHistory,
   updateAssetsForClass,
   updateUserIndexMembers,
-} from '../services/registry_api';
-import { formatDate, formatWeight } from '../../utils/formatting';
+} from '../services/registry_api'
+import { formatDate, formatWeight } from '../../utils/formatting'
 
 // Color palette for pie chart
 const CHART_COLORS = [
-  '#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0', '#9966FF',
-  '#FF9F40', '#E7E9ED', '#7BC225', '#EE82EE', '#00CED1',
-  '#FFD700', '#DC143C', '#00FA9A', '#8A2BE2', '#FF7F50',
-  '#6495ED', '#DEB887', '#5F9EA0', '#D2691E', '#FF69B4',
-];
+  '#FF6384',
+  '#36A2EB',
+  '#FFCE56',
+  '#4BC0C0',
+  '#9966FF',
+  '#FF9F40',
+  '#E7E9ED',
+  '#7BC225',
+  '#EE82EE',
+  '#00CED1',
+  '#FFD700',
+  '#DC143C',
+  '#00FA9A',
+  '#8A2BE2',
+  '#FF7F50',
+  '#6495ED',
+  '#DEB887',
+  '#5F9EA0',
+  '#D2691E',
+  '#FF69B4',
+]
 
 const PIE_CHART_OPTIONS = {
   plugins: {
@@ -61,203 +77,203 @@ const PIE_CHART_OPTIONS = {
   maintainAspectRatio: true,
   aspectRatio: 1,
   responsive: true,
-};
+}
 
 const IndexDetailModal = ({ visible, onClose, indexItem, onRefresh, pushToast }) => {
   // Tab state
-  const [activeTab, setActiveTab] = useState('constituents');
+  const [activeTab, setActiveTab] = useState('constituents')
 
   // Data state
-  const [indexDetail, setIndexDetail] = useState(null);
-  const [loading, setLoading] = useState(false);
-  const [refreshing, setRefreshing] = useState(false);
-  const [error, setError] = useState(null);
+  const [indexDetail, setIndexDetail] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [refreshing, setRefreshing] = useState(false)
+  const [error, setError] = useState(null)
 
   // Edit mode state
-  const [isEditMode, setIsEditMode] = useState(false);
-  const [editableMembers, setEditableMembers] = useState([]);
-  const [originalMembers, setOriginalMembers] = useState([]);
-  const [isSaving, setIsSaving] = useState(false);
+  const [isEditMode, setIsEditMode] = useState(false)
+  const [editableMembers, setEditableMembers] = useState([])
+  const [originalMembers, setOriginalMembers] = useState([])
+  const [isSaving, setIsSaving] = useState(false)
 
   // Sub-modal state
-  const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
-  const [isSaveModalVisible, setIsSaveModalVisible] = useState(false);
-  const [isSymbolDetailModalVisible, setIsSymbolDetailModalVisible] = useState(false);
-  const [selectedCommonSymbol, setSelectedCommonSymbol] = useState(null);
-  const [isDiscardModalVisible, setIsDiscardModalVisible] = useState(false);
-  const [discardAction, setDiscardAction] = useState(null); // 'cancel' or 'close'
+  const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false)
+  const [isSaveModalVisible, setIsSaveModalVisible] = useState(false)
+  const [isSymbolDetailModalVisible, setIsSymbolDetailModalVisible] = useState(false)
+  const [selectedCommonSymbol, setSelectedCommonSymbol] = useState(null)
+  const [isDiscardModalVisible, setIsDiscardModalVisible] = useState(false)
+  const [discardAction, setDiscardAction] = useState(null) // 'cancel' or 'close'
 
   // Historical view state
-  const [asOfDate, setAsOfDate] = useState(null); // null = current, string = historical (YYYY-MM-DD)
-  const [historicalMembers, setHistoricalMembers] = useState(null);
-  const [isLoadingHistorical, setIsLoadingHistorical] = useState(false);
+  const [asOfDate, setAsOfDate] = useState(null) // null = current, string = historical (YYYY-MM-DD)
+  const [historicalMembers, setHistoricalMembers] = useState(null)
+  const [isLoadingHistorical, setIsLoadingHistorical] = useState(false)
 
   // Timeline (history) state
-  const [history, setHistory] = useState(null);
-  const [isLoadingHistory, setIsLoadingHistory] = useState(false);
+  const [history, setHistory] = useState(null)
+  const [isLoadingHistory, setIsLoadingHistory] = useState(false)
 
   // Abort controller for cancelling stale historical view requests
-  const historicalAbortRef = useRef(null);
+  const historicalAbortRef = useRef(null)
 
   // Fetch index details (defined before useEffect that uses it)
   const fetchIndexDetail = useCallback(async () => {
-    if (!indexItem?.class_name) return;
+    if (!indexItem?.class_name) return
 
-    setLoading(true);
-    setError(null);
+    setLoading(true)
+    setError(null)
 
     try {
-      const data = await getIndexDetail(indexItem.class_name);
-      setIndexDetail(data);
+      const data = await getIndexDetail(indexItem.class_name)
+      setIndexDetail(data)
     } catch (err) {
-      setError(err.message || 'Failed to fetch index details');
-      setIndexDetail(null);
+      setError(err.message || 'Failed to fetch index details')
+      setIndexDetail(null)
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  }, [indexItem?.class_name]);
+  }, [indexItem?.class_name])
 
   // Reset state when modal opens/closes
   useEffect(() => {
     if (visible && indexItem) {
-      fetchIndexDetail();
-      setActiveTab('constituents');
-      setIsEditMode(false);
-      setEditableMembers([]);
-      setOriginalMembers([]);
-      setError(null);
+      fetchIndexDetail()
+      setActiveTab('constituents')
+      setIsEditMode(false)
+      setEditableMembers([])
+      setOriginalMembers([])
+      setError(null)
       // Reset historical view
-      setAsOfDate(null);
-      setHistoricalMembers(null);
+      setAsOfDate(null)
+      setHistoricalMembers(null)
       // Reset timeline
-      setHistory(null);
+      setHistory(null)
     }
-  }, [visible, indexItem, fetchIndexDetail]);
+  }, [visible, indexItem, fetchIndexDetail])
 
   // Derived data - simple operations don't need useMemo
-  const members = indexDetail?.members || [];
-  const hasWeights = members.some((m) => m.weight != null);
-  const weightedMembers = members.filter((m) => m.weight != null);
-  const isUserIndex = indexItem?.index_type === 'UserIndex';
+  const members = indexDetail?.members || []
+  const hasWeights = members.some((m) => m.weight != null)
+  const weightedMembers = members.filter((m) => m.weight != null)
+  const isUserIndex = indexItem?.index_type === 'UserIndex'
 
   // Historical view derived state
-  const isViewingHistorical = asOfDate !== null;
-  const displayMembers = isViewingHistorical ? (historicalMembers || []) : members;
+  const isViewingHistorical = asOfDate !== null
+  const displayMembers = isViewingHistorical ? historicalMembers || [] : members
 
   // Handle date change for historical view
   const handleDateChange = async (dateString) => {
     // Cancel any pending request
     if (historicalAbortRef.current) {
-      historicalAbortRef.current.abort();
+      historicalAbortRef.current.abort()
     }
 
     if (!dateString) {
-      setAsOfDate(null);
-      setHistoricalMembers(null);
-      return;
+      setAsOfDate(null)
+      setHistoricalMembers(null)
+      return
     }
 
-    setAsOfDate(dateString);
-    setIsLoadingHistorical(true);
+    setAsOfDate(dateString)
+    setIsLoadingHistorical(true)
 
     // Create new abort controller for this request
-    historicalAbortRef.current = new AbortController();
-    const currentController = historicalAbortRef.current;
+    historicalAbortRef.current = new AbortController()
+    const currentController = historicalAbortRef.current
 
     try {
       // Convert date to end-of-day ISO 8601
-      const asOfDateTime = `${dateString}T23:59:59Z`;
+      const asOfDateTime = `${dateString}T23:59:59Z`
       const response = await getIndexMembers(indexItem.class_name, {
         as_of: asOfDateTime,
         limit: 500,
-      });
+      })
       // Only update if this request wasn't superseded
       if (!currentController.signal.aborted) {
-        setHistoricalMembers(response.items);
+        setHistoricalMembers(response.items)
       }
     } catch (err) {
       // Ignore abort errors
-      if (err.name === 'AbortError') return;
-      console.error('Failed to fetch historical members:', err);
+      if (err.name === 'AbortError') return
+      console.error('Failed to fetch historical members:', err)
       if (pushToast) {
         pushToast({
           title: 'Error',
           body: err.message || 'Failed to fetch historical data',
           color: 'danger',
           icon: cilWarning,
-        });
+        })
       }
       // Reset to current view on error
-      setAsOfDate(null);
-      setHistoricalMembers(null);
+      setAsOfDate(null)
+      setHistoricalMembers(null)
     } finally {
       if (!currentController.signal.aborted) {
-        setIsLoadingHistorical(false);
+        setIsLoadingHistorical(false)
       }
     }
-  };
+  }
 
   // Fetch timeline history
   const fetchHistory = async () => {
-    if (!indexItem?.class_name || history) return; // Don't refetch if already loaded
+    if (!indexItem?.class_name || history) return // Don't refetch if already loaded
 
-    setIsLoadingHistory(true);
+    setIsLoadingHistory(true)
     try {
-      const response = await getIndexHistory(indexItem.class_name);
-      setHistory(response.changes || []);
+      const response = await getIndexHistory(indexItem.class_name)
+      setHistory(response.changes || [])
     } catch (err) {
-      console.error('Failed to fetch history:', err);
+      console.error('Failed to fetch history:', err)
       if (pushToast) {
         pushToast({
           title: 'Error',
           body: err.message || 'Failed to fetch history',
           color: 'danger',
           icon: cilWarning,
-        });
+        })
       }
     } finally {
-      setIsLoadingHistory(false);
+      setIsLoadingHistory(false)
     }
-  };
+  }
 
   // Handle tab change (fetch history when timeline tab is selected)
   const handleTabChange = (tab) => {
-    setActiveTab(tab);
+    setActiveTab(tab)
     if (tab === 'timeline') {
-      fetchHistory();
+      fetchHistory()
     }
-  };
+  }
 
   // Check for unsaved changes
   const hasUnsavedChanges = () => {
-    return JSON.stringify(editableMembers) !== JSON.stringify(originalMembers);
-  };
+    return JSON.stringify(editableMembers) !== JSON.stringify(originalMembers)
+  }
 
   // Handle refresh for IndexProviders
   const handleRefresh = async () => {
-    if (!indexItem) return;
+    if (!indexItem) return
 
-    setRefreshing(true);
-    setError(null);
+    setRefreshing(true)
+    setError(null)
 
     try {
-      await updateAssetsForClass('provider', indexItem.class_name);
-      await fetchIndexDetail();
-      if (onRefresh) onRefresh();
+      await updateAssetsForClass('provider', indexItem.class_name)
+      await fetchIndexDetail()
+      if (onRefresh) onRefresh()
     } catch (err) {
-      setError(err.message || 'Failed to refresh index');
+      setError(err.message || 'Failed to refresh index')
       if (pushToast) {
         pushToast({
           title: 'Refresh Failed',
           body: err.message || 'Failed to refresh index',
           color: 'danger',
           icon: cilWarning,
-        });
+        })
       }
     } finally {
-      setRefreshing(false);
+      setRefreshing(false)
     }
-  };
+  }
 
   // Enter edit mode
   const handleEnterEditMode = () => {
@@ -267,93 +283,89 @@ const IndexDetailModal = ({ visible, onClose, indexItem, onRefresh, pushToast })
       weight: m.weight,
       isNew: false,
       selectOption: null,
-    }));
-    setEditableMembers(editable);
-    setOriginalMembers(editable.map((m) => ({ ...m })));
-    setIsEditMode(true);
-  };
+    }))
+    setEditableMembers(editable)
+    setOriginalMembers(editable.map((m) => ({ ...m })))
+    setIsEditMode(true)
+  }
 
   // Cancel edit mode - show confirmation if unsaved changes
   const handleCancelEdit = () => {
     if (hasUnsavedChanges()) {
-      setDiscardAction('cancel');
-      setIsDiscardModalVisible(true);
+      setDiscardAction('cancel')
+      setIsDiscardModalVisible(true)
     } else {
-      exitEditMode();
+      exitEditMode()
     }
-  };
+  }
 
   // Exit edit mode without saving
   const exitEditMode = () => {
-    setIsEditMode(false);
-    setEditableMembers([]);
-    setOriginalMembers([]);
-  };
+    setIsEditMode(false)
+    setEditableMembers([])
+    setOriginalMembers([])
+  }
 
   // Handle discard confirmation
   const handleDiscardConfirm = () => {
-    setIsDiscardModalVisible(false);
+    setIsDiscardModalVisible(false)
     if (discardAction === 'cancel') {
-      exitEditMode();
+      exitEditMode()
     } else if (discardAction === 'close') {
-      onClose();
+      onClose()
     }
-    setDiscardAction(null);
-  };
+    setDiscardAction(null)
+  }
 
   // Calculate changes summary for save modal
   const changesSummary = useMemo(() => {
-    if (!isEditMode) return { added: [], removed: [], weightChanges: [], totalWeight: 0 };
+    if (!isEditMode) return { added: [], removed: [], weightChanges: [], totalWeight: 0 }
 
-    const originalMap = new Map(
-      originalMembers.map((m) => [m.common_symbol, m.weight])
-    );
+    const originalMap = new Map(originalMembers.map((m) => [m.common_symbol, m.weight]))
     const editedMap = new Map(
-      editableMembers
-        .filter((m) => m.common_symbol)
-        .map((m) => [m.common_symbol, m.weight])
-    );
+      editableMembers.filter((m) => m.common_symbol).map((m) => [m.common_symbol, m.weight]),
+    )
 
-    const added = [];
-    const removed = [];
-    const weightChanges = [];
+    const added = []
+    const removed = []
+    const weightChanges = []
 
     // Find added and changed
     for (const [symbol, weight] of editedMap) {
       if (!originalMap.has(symbol)) {
-        added.push(symbol);
+        added.push(symbol)
       } else if (originalMap.get(symbol) !== weight) {
         weightChanges.push({
           symbol,
           old: originalMap.get(symbol),
           new: weight,
-        });
+        })
       }
     }
 
     // Find removed
     for (const symbol of originalMap.keys()) {
       if (!editedMap.has(symbol)) {
-        removed.push(symbol);
+        removed.push(symbol)
       }
     }
 
     const totalWeight = Array.from(editedMap.values())
       .filter((w) => w != null)
-      .reduce((sum, w) => sum + w, 0);
+      .reduce((sum, w) => sum + w, 0)
 
-    return { added, removed, weightChanges, totalWeight };
-  }, [isEditMode, editableMembers, originalMembers]);
+    return { added, removed, weightChanges, totalWeight }
+  }, [isEditMode, editableMembers, originalMembers])
 
   // Calculate total weight for edit mode display
   const editTotalWeight = editableMembers
     .filter((m) => m.weight != null)
-    .reduce((sum, m) => sum + m.weight, 0);
+    .reduce((sum, m) => sum + m.weight, 0)
 
   // Handle save
   const handleSave = async () => {
-    setIsSaving(true);
-    setError(null);
+    setIsSaving(true)
+    setError(null)
 
     try {
       const membersPayload = editableMembers
@@ -361,141 +373,127 @@ const IndexDetailModal = ({ visible, onClose, indexItem, onRefresh, pushToast })
         .map((m) => ({
           common_symbol: m.common_symbol,
           weight: m.weight,
-        }));
+        }))
 
-      await updateUserIndexMembers(indexItem.class_name, { members: membersPayload });
+      await updateUserIndexMembers(indexItem.class_name, { members: membersPayload })
 
       if (pushToast) {
         pushToast({
           title: 'Index Updated',
           body: `Index "${indexItem.class_name}" has been updated successfully.`,
           color: 'success',
-        });
+        })
       }
 
-      setIsSaveModalVisible(false);
-      setIsEditMode(false);
-      await fetchIndexDetail();
-      if (onRefresh) onRefresh();
+      setIsSaveModalVisible(false)
+      setIsEditMode(false)
+      await fetchIndexDetail()
+      if (onRefresh) onRefresh()
     } catch (err) {
-      setError(err.message || 'Failed to save changes');
+      setError(err.message || 'Failed to save changes')
       if (pushToast) {
         pushToast({
           title: 'Save Failed',
           body: err.message || 'Failed to save changes',
           color: 'danger',
           icon: cilWarning,
-        });
+        })
       }
     } finally {
-      setIsSaving(false);
+      setIsSaving(false)
     }
-  };
+  }
 
   // Handle delete success
   const handleDeleteSuccess = () => {
-    setIsDeleteModalVisible(false);
-    onClose();
-    if (onRefresh) onRefresh();
-  };
+    setIsDeleteModalVisible(false)
+    onClose()
+    if (onRefresh) onRefresh()
+  }
 
   // Weight utilities
   const handleNormalize = () => {
-    const withWeights = editableMembers.filter((m) => m.weight != null);
-    const total = withWeights.reduce((sum, m) => sum + m.weight, 0);
+    const withWeights = editableMembers.filter((m) => m.weight != null)
+    const total = withWeights.reduce((sum, m) => sum + m.weight, 0)
 
     if (total === 0) {
-      handleEqualWeight();
-      return;
+      handleEqualWeight()
+      return
     }
 
     setEditableMembers((prev) =>
-      prev.map((m) =>
-        m.weight != null ? { ...m, weight: m.weight / total } : m
-      )
-    );
-  };
+      prev.map((m) => (m.weight != null ? { ...m, weight: m.weight / total } : m)),
+    )
+  }
 
   const handleEqualWeight = () => {
-    const count = editableMembers.length;
-    if (count === 0) return;
-    const equalWeight = 1 / count;
+    const count = editableMembers.length
+    if (count === 0) return
+    const equalWeight = 1 / count
 
-    setEditableMembers((prev) =>
-      prev.map((m) => ({ ...m, weight: equalWeight }))
-    );
-  };
+    setEditableMembers((prev) => prev.map((m) => ({ ...m, weight: equalWeight })))
+  }
 
   // Handle common symbol click (view mode) - opens symbol detail modal
   const handleCommonSymbolClick = (member) => {
-    const symbol = member.mapped_common_symbol || member.common_symbol;
+    const symbol = member.mapped_common_symbol || member.common_symbol
     if (symbol) {
-      setSelectedCommonSymbol(symbol);
-      setIsSymbolDetailModalVisible(true);
+      setSelectedCommonSymbol(symbol)
+      setIsSymbolDetailModalVisible(true)
     }
-  };
+  }
 
   // Handle modal close with unsaved changes check
   const handleClose = () => {
     if (isEditMode && hasUnsavedChanges()) {
-      setDiscardAction('close');
-      setIsDiscardModalVisible(true);
+      setDiscardAction('close')
+      setIsDiscardModalVisible(true)
     } else {
-      onClose();
+      onClose()
     }
-  };
+  }
 
   // Get badge color for index type
   const getTypeBadgeColor = (indexType) => {
-    return indexType === 'IndexProvider' ? 'primary' : 'success';
-  };
+    return indexType === 'IndexProvider' ? 'primary' : 'success'
+  }
 
   // Prepare pie chart data with "Others" aggregation for <1% weights
   const pieChartData = useMemo(() => {
-    if (!weightedMembers.length) return null;
+    if (!weightedMembers.length) return null
 
-    const significantMembers = weightedMembers.filter((m) => m.weight >= 0.01);
-    const smallMembers = weightedMembers.filter((m) => m.weight < 0.01);
-    const othersWeight = smallMembers.reduce((sum, m) => sum + m.weight, 0);
+    const significantMembers = weightedMembers.filter((m) => m.weight >= 0.01)
+    const smallMembers = weightedMembers.filter((m) => m.weight < 0.01)
+    const othersWeight = smallMembers.reduce((sum, m) => sum + m.weight, 0)
 
-    const labels = significantMembers.map(
-      (m) => m.effective_symbol || m.common_symbol || 'Unknown'
-    );
-    const data = significantMembers.map((m) => m.weight * 100);
-    const colors = significantMembers.map((_, i) => CHART_COLORS[i % CHART_COLORS.length]);
+    const labels = significantMembers.map((m) => m.effective_symbol || m.common_symbol || 'Unknown')
+    const data = significantMembers.map((m) => m.weight * 100)
+    const colors = significantMembers.map((_, i) => CHART_COLORS[i % CHART_COLORS.length])
 
     if (smallMembers.length > 0 && othersWeight > 0) {
-      labels.push(`Others (${smallMembers.length})`);
-      data.push(othersWeight * 100);
-      colors.push('#9E9E9E');
+      labels.push(`Others (${smallMembers.length})`)
+      data.push(othersWeight * 100)
+      colors.push('#9E9E9E')
     }
 
     return {
       labels,
       datasets: [{ data, backgroundColor: colors, hoverBackgroundColor: colors }],
-    };
-  }, [weightedMembers]);
+    }
+  }, [weightedMembers])
 
   // Check for validation issues in edit mode
   const hasValidationErrors = useMemo(() => {
-    if (!isEditMode) return false;
-    const symbols = editableMembers
-      .map((m) => m.common_symbol)
-      .filter((s) => s !== null);
-    const hasDuplicates = symbols.length !== new Set(symbols).size;
-    const hasEmptyNewRows = editableMembers.some((m) => m.isNew && !m.common_symbol);
-    return hasDuplicates || hasEmptyNewRows;
-  }, [isEditMode, editableMembers]);
+    if (!isEditMode) return false
+    const symbols = editableMembers.map((m) => m.common_symbol).filter((s) => s !== null)
+    const hasDuplicates = symbols.length !== new Set(symbols).size
+    const hasEmptyNewRows = editableMembers.some((m) => m.isNew && !m.common_symbol)
+    return hasDuplicates || hasEmptyNewRows
+  }, [isEditMode, editableMembers])
 
   return (
     <>
-      <CModal
-        visible={visible}
-        onClose={handleClose}
-        backdrop="static"
-        size="lg"
-        scrollable
-      >
+      <CModal visible={visible} onClose={handleClose} backdrop="static" size="lg" scrollable>
         <CModalHeader onClose={handleClose}>
           <CModalTitle className="d-flex align-items-center gap-2">
             <strong>{indexItem?.class_name || 'Index Details'}</strong>
@@ -505,9 +503,7 @@ const IndexDetailModal = ({ visible, onClose, indexItem, onRefresh, pushToast })
               </CBadge>
             )}
             {indexDetail?.index?.current_member_count !== undefined && (
-              <small className="text-muted">
-                {indexDetail.index.current_member_count} members
-              </small>
+              <small className="text-muted">{indexDetail.index.current_member_count} members</small>
             )}
             {isEditMode && (
               <CBadge color="warning" className="ms-2">
@@ -702,9 +698,7 @@ const IndexDetailModal = ({ visible, onClose, indexItem, onRefresh, pushToast })
                               <CTableRow>
                                 <CTableHeaderCell>Symbol</CTableHeaderCell>
                                 <CTableHeaderCell>Common Symbol</CTableHeaderCell>
-                                <CTableHeaderCell className="text-end">
-                                  Weight
-                                </CTableHeaderCell>
+                                <CTableHeaderCell className="text-end">Weight</CTableHeaderCell>
                                 <CTableHeaderCell>Valid From</CTableHeaderCell>
                               </CTableRow>
                             </CTableHead>
@@ -770,10 +764,7 @@ const IndexDetailModal = ({ visible, onClose, indexItem, onRefresh, pushToast })
                             aspectRatio: '1',
                           }}
                         >
-                          <CChartPie
-                            data={pieChartData}
-                            options={PIE_CHART_OPTIONS}
-                          />
+                          <CChartPie data={pieChartData} options={PIE_CHART_OPTIONS} />
                         </div>
                       </div>
                     )}
@@ -821,8 +812,7 @@ const IndexDetailModal = ({ visible, onClose, indexItem, onRefresh, pushToast })
                                 key={eventIdx}
                                 className={event.type === 'added' ? 'text-success' : 'text-danger'}
                               >
-                                {event.type === 'added' ? '+' : '−'}{' '}
-                                {event.symbol}
+                                {event.type === 'added' ? '+' : '−'} {event.symbol}
                                 {event.weight != null && ` ${(event.weight * 100).toFixed(0)}%`}
                               </div>
                             ))}
@@ -845,11 +835,7 @@ const IndexDetailModal = ({ visible, onClose, indexItem, onRefresh, pushToast })
           {isEditMode ? (
             /* Edit mode footer */
             <>
-              <CButton
-                color="secondary"
-                onClick={handleCancelEdit}
-                disabled={isSaving}
-              >
+              <CButton color="secondary" onClick={handleCancelEdit} disabled={isSaving}>
                 Cancel
               </CButton>
               <CButton
@@ -891,8 +877,8 @@ const IndexDetailModal = ({ visible, onClose, indexItem, onRefresh, pushToast })
       <CommonSymbolDetailModal
         visible={isSymbolDetailModalVisible}
         onClose={() => {
-          setIsSymbolDetailModalVisible(false);
-          setSelectedCommonSymbol(null);
+          setIsSymbolDetailModalVisible(false)
+          setSelectedCommonSymbol(null)
         }}
         commonSymbol={selectedCommonSymbol}
       />
@@ -927,7 +913,7 @@ const IndexDetailModal = ({ visible, onClose, indexItem, onRefresh, pushToast })
         confirmColor="danger"
       />
     </>
-  );
-};
+  )
+}
 
-export default IndexDetailModal;
+export default IndexDetailModal

--- a/web/src/views/indices/Indices.js
+++ b/web/src/views/indices/Indices.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react'
 import {
   CButton,
   CCard,
@@ -14,29 +14,29 @@ import {
   CToastHeader,
   CToastBody,
   CSpinner,
-} from '@coreui/react-pro';
-import CIcon from '@coreui/icons-react';
-import { cilCheckCircle, cilWarning, cilPlus } from '@coreui/icons';
+} from '@coreui/react-pro'
+import CIcon from '@coreui/icons-react'
+import { cilCheckCircle, cilWarning, cilPlus } from '@coreui/icons'
 
-import IndexDetailModal from './IndexDetailModal';
-import CreateIndexModal from './CreateIndexModal';
-import { getIndices } from '../services/registry_api';
-import { formatDate } from '../../utils/formatting';
+import IndexDetailModal from './IndexDetailModal'
+import CreateIndexModal from './CreateIndexModal'
+import { getIndices } from '../services/registry_api'
+import { formatDate } from '../../utils/formatting'
 
 const Indices = () => {
   // Data state
-  const [indices, setIndices] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const [indices, setIndices] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
 
   // Modal state
-  const [selectedIndex, setSelectedIndex] = useState(null);
-  const [isDetailModalVisible, setIsDetailModalVisible] = useState(false);
-  const [isCreateModalVisible, setIsCreateModalVisible] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(null)
+  const [isDetailModalVisible, setIsDetailModalVisible] = useState(false)
+  const [isCreateModalVisible, setIsCreateModalVisible] = useState(false)
 
   // Toast state
-  const [toastToShow, setToastToShow] = useState(null);
-  const toasterRef = useRef(null);
+  const [toastToShow, setToastToShow] = useState(null)
+  const toasterRef = useRef(null)
 
   const pushToast = ({ title, body, color = 'info', icon = null }) => {
     const toast = (
@@ -47,79 +47,79 @@ const Indices = () => {
         </CToastHeader>
         <CToastBody>{body}</CToastBody>
       </CToast>
-    );
-    setToastToShow(toast);
-  };
+    )
+    setToastToShow(toast)
+  }
 
   // Fetch all indices
   const fetchIndices = async () => {
-    setLoading(true);
-    setError(null);
+    setLoading(true)
+    setError(null)
 
     try {
-      const data = await getIndices({ limit: 100 });
-      setIndices(data.items || []);
+      const data = await getIndices({ limit: 100 })
+      setIndices(data.items || [])
     } catch (err) {
-      setError(err.message || 'Failed to fetch indices');
-      setIndices([]);
+      setError(err.message || 'Failed to fetch indices')
+      setIndices([])
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  };
+  }
 
   useEffect(() => {
-    fetchIndices();
-  }, []);
+    fetchIndices()
+  }, [])
 
   // Handle row click to open detail modal
   const handleRowClick = (item) => {
-    setSelectedIndex(item);
-    setIsDetailModalVisible(true);
-  };
+    setSelectedIndex(item)
+    setIsDetailModalVisible(true)
+  }
 
   // Handle modal close
   const handleModalClose = () => {
-    setIsDetailModalVisible(false);
-    setSelectedIndex(null);
-  };
+    setIsDetailModalVisible(false)
+    setSelectedIndex(null)
+  }
 
   // Handle refresh callback from modal
   const handleRefresh = () => {
-    fetchIndices();
+    fetchIndices()
     pushToast({
       title: 'Index Refreshed',
       body: 'Index data has been updated successfully.',
       color: 'success',
       icon: cilCheckCircle,
-    });
-  };
+    })
+  }
 
   // Get badge color for index type
   const getTypeBadgeColor = (indexType) => {
-    return indexType === 'IndexProvider' ? 'primary' : 'success';
-  };
+    return indexType === 'IndexProvider' ? 'primary' : 'success'
+  }
 
   // Format sync frequency for display
   const formatSyncFrequency = (item) => {
     // Only IndexProviders have sync frequency
     if (item.index_type !== 'IndexProvider') {
-      return 'N/A';
+      return 'N/A'
     }
-    const freq = item.preferences?.scheduling?.sync_frequency;
+    const freq = item.preferences?.scheduling?.sync_frequency
     if (!freq) {
-      return 'Weekly'; // Default per spec
+      return 'Weekly' // Default per spec
     }
     switch (freq) {
       case '1d':
-        return 'Daily';
+        return 'Daily'
       case '1w':
-        return 'Weekly';
+        return 'Weekly'
       case '1M':
-        return 'Monthly';
+        return 'Monthly'
       default:
-        return freq;
+        return freq
     }
-  };
+  }
 
   // Table columns - use width: '1%' + whiteSpace: 'nowrap' for auto-fit
   const columns = [
@@ -159,7 +159,7 @@ const Indices = () => {
       sorter: true,
       filter: false,
     },
-  ];
+  ]
 
   return (
     <>
@@ -172,10 +172,7 @@ const Indices = () => {
                   <h5 className="mb-0">Indices</h5>
                 </CCol>
                 <CCol xs="auto">
-                  <CButton
-                    color="primary"
-                    onClick={() => setIsCreateModalVisible(true)}
-                  >
+                  <CButton color="primary" onClick={() => setIsCreateModalVisible(true)}>
                     <CIcon icon={cilPlus} className="me-1" />
                     Create Index
                   </CButton>
@@ -228,17 +225,11 @@ const Indices = () => {
                         </CBadge>
                       </td>
                     ),
-                    sync_frequency: (item) => (
-                      <td>{formatSyncFrequency(item)}</td>
-                    ),
+                    sync_frequency: (item) => <td>{formatSyncFrequency(item)}</td>,
                     current_member_count: (item) => (
-                      <td className="text-center">
-                        {item.current_member_count ?? 0}
-                      </td>
+                      <td className="text-center">{item.current_member_count ?? 0}</td>
                     ),
-                    uploaded_at: (item) => (
-                      <td>{formatDate(item.uploaded_at)}</td>
-                    ),
+                    uploaded_at: (item) => <td>{formatDate(item.uploaded_at)}</td>,
                   }}
                   noItemsLabel="No indices found"
                 />
@@ -265,7 +256,7 @@ const Indices = () => {
 
       <CToaster ref={toasterRef} push={toastToShow} placement="top-end" />
     </>
-  );
-};
+  )
+}
 
-export default Indices;
+export default Indices

--- a/web/src/views/indices/SaveChangesModal.js
+++ b/web/src/views/indices/SaveChangesModal.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 import {
   CModal,
   CModalHeader,
@@ -9,31 +9,20 @@ import {
   CSpinner,
   CAlert,
   CBadge,
-} from '@coreui/react-pro';
-import CIcon from '@coreui/icons-react';
-import { cilCheckCircle, cilWarning, cilPlus, cilMinus, cilPencil } from '@coreui/icons';
-import { formatWeight } from '../../utils/formatting';
+} from '@coreui/react-pro'
+import CIcon from '@coreui/icons-react'
+import { cilCheckCircle, cilWarning, cilPlus, cilMinus, cilPencil } from '@coreui/icons'
+import { formatWeight } from '../../utils/formatting'
 
-const SaveChangesModal = ({
-  visible,
-  onClose,
-  onConfirm,
-  isSaving,
-  changesSummary,
-  indexName,
-}) => {
-  const { added = [], removed = [], weightChanges = [], totalWeight = 0 } = changesSummary || {};
+const SaveChangesModal = ({ visible, onClose, onConfirm, isSaving, changesSummary, indexName }) => {
+  const { added = [], removed = [], weightChanges = [], totalWeight = 0 } = changesSummary || {}
 
-  const hasChanges = added.length > 0 || removed.length > 0 || weightChanges.length > 0;
-  const totalWeightPercent = (totalWeight * 100).toFixed(1);
-  const isWeightValid = Math.abs(totalWeight - 1) < 0.001; // Within 0.1% of 100%
+  const hasChanges = added.length > 0 || removed.length > 0 || weightChanges.length > 0
+  const totalWeightPercent = (totalWeight * 100).toFixed(1)
+  const isWeightValid = Math.abs(totalWeight - 1) < 0.001 // Within 0.1% of 100%
 
   return (
-    <CModal
-      visible={visible}
-      onClose={onClose}
-      backdrop="static"
-    >
+    <CModal visible={visible} onClose={onClose} backdrop="static">
       <CModalHeader onClose={onClose}>
         <CModalTitle>
           <CIcon icon={cilCheckCircle} className="me-2" />
@@ -128,18 +117,10 @@ const SaveChangesModal = ({
       </CModalBody>
 
       <CModalFooter>
-        <CButton
-          color="secondary"
-          onClick={onClose}
-          disabled={isSaving}
-        >
+        <CButton color="secondary" onClick={onClose} disabled={isSaving}>
           Cancel
         </CButton>
-        <CButton
-          color="primary"
-          onClick={onConfirm}
-          disabled={isSaving || !hasChanges}
-        >
+        <CButton color="primary" onClick={onConfirm} disabled={isSaving || !hasChanges}>
           {isSaving ? (
             <>
               <CSpinner size="sm" className="me-1" />
@@ -151,7 +132,7 @@ const SaveChangesModal = ({
         </CButton>
       </CModalFooter>
     </CModal>
-  );
-};
+  )
+}
 
-export default SaveChangesModal;
+export default SaveChangesModal

--- a/web/src/views/mappings/CommonSymbolDetailModal.js
+++ b/web/src/views/mappings/CommonSymbolDetailModal.js
@@ -1,64 +1,64 @@
-import { React, useState, useEffect } from 'react';
+import { React, useState, useEffect } from 'react'
 import {
-    CModal,
-    CModalHeader,
-    CModalTitle,
-    CModalBody,
-    CModalFooter,
-    CButton,
-    CTable,
-    CTableHead,
-    CTableRow,
-    CTableHeaderCell,
-    CTableBody,
-    CTableDataCell,
-    CBadge,
-    CSpinner,
-    CAlert,
-} from '@coreui/react-pro';
+  CModal,
+  CModalHeader,
+  CModalTitle,
+  CModalBody,
+  CModalFooter,
+  CButton,
+  CTable,
+  CTableHead,
+  CTableRow,
+  CTableHeaderCell,
+  CTableBody,
+  CTableDataCell,
+  CBadge,
+  CSpinner,
+  CAlert,
+} from '@coreui/react-pro'
 
 // API Imports
-import { getAssetMappingsForSymbol } from '../services/registry_api';
+import { getAssetMappingsForSymbol } from '../services/registry_api'
 
 // Component Imports
-import CommonSymbolRenameModal from './CommonSymbolRenameModal';
+import CommonSymbolRenameModal from './CommonSymbolRenameModal'
 
 const CommonSymbolDetailModal = ({ visible, onClose, onRenameSuccess, commonSymbol }) => {
-  const [mappings, setMappings] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
-  const [isRenameModalVisible, setIsRenameModalVisible] = useState(false);
+  const [mappings, setMappings] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [isRenameModalVisible, setIsRenameModalVisible] = useState(false)
 
   const handleRenameSuccess = (result) => {
-    setIsRenameModalVisible(false);
+    setIsRenameModalVisible(false)
     if (onRenameSuccess) {
-      onRenameSuccess(result);
+      onRenameSuccess(result)
     }
-    onClose();
-  };
+    onClose()
+  }
 
   useEffect(() => {
     const fetchMappingsForSymbol = async () => {
-      if (!commonSymbol) return;
+      if (!commonSymbol) return
 
-      setLoading(true);
-      setError(null);
+      setLoading(true)
+      setError(null)
       try {
         // Use the new efficient API endpoint that filters by common symbol server-side
-        const mappings = await getAssetMappingsForSymbol(commonSymbol);
-        setMappings(mappings);
+        const mappings = await getAssetMappingsForSymbol(commonSymbol)
+        setMappings(mappings)
       } catch (err) {
-        console.error('Error fetching mappings for symbol:', err);
-        setError(err.message || 'Failed to fetch mappings for this symbol');
+        console.error('Error fetching mappings for symbol:', err)
+        setError(err.message || 'Failed to fetch mappings for this symbol')
       } finally {
-        setLoading(false);
+        setLoading(false)
       }
-    };
+    }
 
     if (visible && commonSymbol) {
-      fetchMappingsForSymbol();
+      fetchMappingsForSymbol()
     }
-  }, [visible, commonSymbol]);
+  }, [visible, commonSymbol])
 
   const getClassBadge = (class_type) => {
     switch (class_type) {
@@ -72,11 +72,11 @@ const CommonSymbolDetailModal = ({ visible, onClose, onRenameSuccess, commonSymb
         return 'primary'
       }
     }
-  };
+  }
 
   const getActiveBadge = (is_active) => {
-    return is_active ? 'success' : 'danger';
-  };
+    return is_active ? 'success' : 'danger'
+  }
 
   return (
     <CModal
@@ -109,9 +109,7 @@ const CommonSymbolDetailModal = ({ visible, onClose, onRenameSuccess, commonSymb
         )}
 
         {!loading && !error && mappings.length === 0 && (
-          <CAlert color="info">
-            No mappings found for common symbol "{commonSymbol}".
-          </CAlert>
+          <CAlert color="info">No mappings found for common symbol "{commonSymbol}".</CAlert>
         )}
 
         {!loading && !error && mappings.length > 0 && (
@@ -146,12 +144,8 @@ const CommonSymbolDetailModal = ({ visible, onClose, onRenameSuccess, commonSymb
                     <CTableDataCell>
                       <code>{mapping.class_symbol}</code>
                     </CTableDataCell>
-                    <CTableDataCell>
-                      {mapping.primary_id || '-'}
-                    </CTableDataCell>
-                    <CTableDataCell>
-                      {mapping.asset_class || '-'}
-                    </CTableDataCell>
+                    <CTableDataCell>{mapping.primary_id || '-'}</CTableDataCell>
+                    <CTableDataCell>{mapping.asset_class || '-'}</CTableDataCell>
                     <CTableDataCell className="text-center">
                       <CBadge color={getActiveBadge(mapping.is_active)}>
                         {mapping.is_active ? 'Active' : 'Inactive'}
@@ -181,7 +175,7 @@ const CommonSymbolDetailModal = ({ visible, onClose, onRenameSuccess, commonSymb
         commonSymbol={commonSymbol}
       />
     </CModal>
-  );
-};
+  )
+}
 
-export default CommonSymbolDetailModal;
+export default CommonSymbolDetailModal

--- a/web/src/views/mappings/CommonSymbolDetailModal.js
+++ b/web/src/views/mappings/CommonSymbolDetailModal.js
@@ -23,6 +23,9 @@ import { getAssetMappingsForSymbol } from '../services/registry_api'
 // Component Imports
 import CommonSymbolRenameModal from './CommonSymbolRenameModal'
 
+// Utils
+import { getClassBadge, getActiveBadge } from '../../utils/badgeHelpers'
+
 const CommonSymbolDetailModal = ({ visible, onClose, onRenameSuccess, commonSymbol }) => {
   const [mappings, setMappings] = useState([])
   const [loading, setLoading] = useState(false)
@@ -59,24 +62,6 @@ const CommonSymbolDetailModal = ({ visible, onClose, onRenameSuccess, commonSymb
       fetchMappingsForSymbol()
     }
   }, [visible, commonSymbol])
-
-  const getClassBadge = (class_type) => {
-    switch (class_type) {
-      case 'provider': {
-        return 'primary'
-      }
-      case 'broker': {
-        return 'secondary'
-      }
-      default: {
-        return 'primary'
-      }
-    }
-  }
-
-  const getActiveBadge = (is_active) => {
-    return is_active ? 'success' : 'danger'
-  }
 
   return (
     <CModal

--- a/web/src/views/mappings/CommonSymbolRenameModal.js
+++ b/web/src/views/mappings/CommonSymbolRenameModal.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react'
 import {
   CModal,
   CModalHeader,
@@ -11,57 +11,57 @@ import {
   CFormInput,
   CSpinner,
   CAlert,
-} from '@coreui/react-pro';
+} from '@coreui/react-pro'
 
-import { renameCommonSymbol } from '../services/registry_api';
+import { renameCommonSymbol } from '../services/registry_api'
 
 const CommonSymbolRenameModal = ({ visible, onClose, onSuccess, commonSymbol }) => {
-  const [newSymbol, setNewSymbol] = useState('');
-  const [isRenaming, setIsRenaming] = useState(false);
-  const [error, setError] = useState(null);
+  const [newSymbol, setNewSymbol] = useState('')
+  const [isRenaming, setIsRenaming] = useState(false)
+  const [error, setError] = useState(null)
 
   useEffect(() => {
     if (visible) {
-      setNewSymbol('');
-      setError(null);
+      setNewSymbol('')
+      setError(null)
     }
-  }, [visible]);
+  }, [visible])
 
   const handleRename = async () => {
-    const trimmedNewSymbol = newSymbol.trim();
+    const trimmedNewSymbol = newSymbol.trim()
 
     if (!trimmedNewSymbol) {
-      setError('New symbol name cannot be empty.');
-      return;
+      setError('New symbol name cannot be empty.')
+      return
     }
 
     if (trimmedNewSymbol === commonSymbol) {
-      setError('New symbol name must be different from the current name.');
-      return;
+      setError('New symbol name must be different from the current name.')
+      return
     }
 
-    setIsRenaming(true);
-    setError(null);
+    setIsRenaming(true)
+    setError(null)
 
     try {
-      const result = await renameCommonSymbol(commonSymbol, trimmedNewSymbol);
+      const result = await renameCommonSymbol(commonSymbol, trimmedNewSymbol)
       if (onSuccess) {
-        onSuccess(result);
+        onSuccess(result)
       }
-      onClose();
+      onClose()
     } catch (err) {
-      setError(err.message || 'Failed to rename symbol. Please try again.');
+      setError(err.message || 'Failed to rename symbol. Please try again.')
     } finally {
-      setIsRenaming(false);
+      setIsRenaming(false)
     }
-  };
+  }
 
   const handleKeyDown = (e) => {
     if (e.key === 'Enter' && !isRenaming) {
-      e.preventDefault();
-      handleRename();
+      e.preventDefault()
+      handleRename()
     }
-  };
+  }
 
   return (
     <CModal visible={visible} onClose={onClose} backdrop="static">
@@ -114,7 +114,7 @@ const CommonSymbolRenameModal = ({ visible, onClose, onSuccess, commonSymbol }) 
         </CModalFooter>
       </CForm>
     </CModal>
-  );
-};
+  )
+}
 
-export default CommonSymbolRenameModal;
+export default CommonSymbolRenameModal

--- a/web/src/views/mappings/CommonSymbolsTab.js
+++ b/web/src/views/mappings/CommonSymbolsTab.js
@@ -1,290 +1,288 @@
 /**
  * Common Symbols tab component with server-side pagination, sorting, and filtering.
- * 
+ *
  * Follows the same patterns as Assets.js for server-side data management.
  */
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react'
 import {
-    CCard,
-    CCardBody,
-    CCardHeader,
-    CCol,
-    CRow,
-    CSmartTable,
-    CSmartPagination,
-    CFormSelect,
-    CBadge,
-    CAlert,
-    CButton,
-    CFormInput,
-    CInputGroup,
-    CInputGroupText,
-} from '@coreui/react-pro';
-import CIcon from '@coreui/icons-react';
-import { cilSearch, cilZoom } from '@coreui/icons';
-import { getCommonSymbols } from '../services/registry_api';
-import CommonSymbolDetailModal from './CommonSymbolDetailModal';
+  CCard,
+  CCardBody,
+  CCardHeader,
+  CCol,
+  CRow,
+  CSmartTable,
+  CSmartPagination,
+  CFormSelect,
+  CBadge,
+  CAlert,
+  CButton,
+  CFormInput,
+  CInputGroup,
+  CInputGroupText,
+} from '@coreui/react-pro'
+import CIcon from '@coreui/icons-react'
+import { cilSearch, cilZoom } from '@coreui/icons'
+import { getCommonSymbols } from '../services/registry_api'
+import CommonSymbolDetailModal from './CommonSymbolDetailModal'
 
 const CommonSymbolsTab = () => {
-    // Data state
-    const [items, setItems] = useState([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState(null);
-    const [totalItems, setTotalItems] = useState(0);
+  // Data state
+  const [items, setItems] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [totalItems, setTotalItems] = useState(0)
 
-    // Pagination state (simple primitives, not objects)
-    const [activePage, setActivePage] = useState(1);
-    const [itemsPerPage, setItemsPerPage] = useState(25);
+  // Pagination state (simple primitives, not objects)
+  const [activePage, setActivePage] = useState(1)
+  const [itemsPerPage, setItemsPerPage] = useState(25)
 
-    // Sorting state
-    const [sorter, setSorter] = useState({ column: 'common_symbol', direction: 'asc' });
+  // Sorting state
+  const [sorter, setSorter] = useState({ column: 'common_symbol', direction: 'asc' })
 
-    // Filter state
-    const [searchInput, setSearchInput] = useState('');
-    const [searchFilter, setSearchFilter] = useState('');
+  // Filter state
+  const [searchInput, setSearchInput] = useState('')
+  const [searchFilter, setSearchFilter] = useState('')
 
-    // Modal state
-    const [isDetailModalVisible, setIsDetailModalVisible] = useState(false);
-    const [selectedSymbol, setSelectedSymbol] = useState(null);
+  // Modal state
+  const [isDetailModalVisible, setIsDetailModalVisible] = useState(false)
+  const [selectedSymbol, setSelectedSymbol] = useState(null)
 
-    // Fetch data function (not wrapped in useCallback - defined inline like Assets.js)
-    const fetchData = async () => {
-        setLoading(true);
-        setError(null);
+  // Fetch data function (not wrapped in useCallback - defined inline like Assets.js)
+  const fetchData = async () => {
+    setLoading(true)
+    setError(null)
 
-        const apiParams = {
-            limit: itemsPerPage,
-            offset: (activePage - 1) * itemsPerPage,
-        };
+    const apiParams = {
+      limit: itemsPerPage,
+      offset: (activePage - 1) * itemsPerPage,
+    }
 
-        if (sorter.column) {
-            apiParams.sort_by = sorter.column;
-            apiParams.sort_order = sorter.direction || 'asc';
-        }
+    if (sorter.column) {
+      apiParams.sort_by = sorter.column
+      apiParams.sort_order = sorter.direction || 'asc'
+    }
 
-        if (searchFilter) {
-            apiParams.common_symbol_like = searchFilter;
-        }
+    if (searchFilter) {
+      apiParams.common_symbol_like = searchFilter
+    }
 
-        try {
-            const data = await getCommonSymbols(apiParams);
-            setItems(data.items || []);
-            setTotalItems(data.total_items || 0);
-        } catch (err) {
-            console.error('Error fetching common symbols:', err);
-            setError(err.message || 'Failed to fetch common symbols');
-            setItems([]);
-            setTotalItems(0);
-        } finally {
-            setLoading(false);
-        }
-    };
+    try {
+      const data = await getCommonSymbols(apiParams)
+      setItems(data.items || [])
+      setTotalItems(data.total_items || 0)
+    } catch (err) {
+      console.error('Error fetching common symbols:', err)
+      setError(err.message || 'Failed to fetch common symbols')
+      setItems([])
+      setTotalItems(0)
+    } finally {
+      setLoading(false)
+    }
+  }
 
-    // Debounce search input -> searchFilter
-    useEffect(() => {
-        const timer = setTimeout(() => {
-            if (searchInput !== searchFilter) {
-                setSearchFilter(searchInput);
-                setActivePage(1); // Reset to first page on search
-            }
-        }, 500);
-        return () => clearTimeout(timer);
-    }, [searchInput, searchFilter]);
+  // Debounce search input -> searchFilter
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (searchInput !== searchFilter) {
+        setSearchFilter(searchInput)
+        setActivePage(1) // Reset to first page on search
+      }
+    }, 500)
+    return () => clearTimeout(timer)
+  }, [searchInput, searchFilter])
 
-    // Fetch data when dependencies change (simple primitives only)
-    useEffect(() => {
-        fetchData();
-    }, [activePage, itemsPerPage, sorter.column, sorter.direction, searchFilter]);
+  // Fetch data when dependencies change (simple primitives only)
+  useEffect(() => {
+    fetchData()
+  }, [activePage, itemsPerPage, sorter.column, sorter.direction, searchFilter])
 
-    // Calculate total pages
-    const totalPages = totalItems > 0 ? Math.ceil(totalItems / itemsPerPage) : 1;
+  // Calculate total pages
+  const totalPages = totalItems > 0 ? Math.ceil(totalItems / itemsPerPage) : 1
 
-    // Event handlers
-    const handleItemsPerPageChange = (event) => {
-        const newSize = parseInt(event.target.value, 10);
-        setActivePage(1);
-        setItemsPerPage(newSize);
-    };
+  // Event handlers
+  const handleItemsPerPageChange = (event) => {
+    const newSize = parseInt(event.target.value, 10)
+    setActivePage(1)
+    setItemsPerPage(newSize)
+  }
 
-    const handleSorterChange = (sorterData) => {
-        if (!sorterData || sorterData.state === 0) {
-            setSorter({ column: 'common_symbol', direction: 'asc' });
-        } else {
-            setSorter({ column: sorterData.column, direction: sorterData.state });
-        }
-        setActivePage(1);
-    };
+  const handleSorterChange = (sorterData) => {
+    if (!sorterData || sorterData.state === 0) {
+      setSorter({ column: 'common_symbol', direction: 'asc' })
+    } else {
+      setSorter({ column: sorterData.column, direction: sorterData.state })
+    }
+    setActivePage(1)
+  }
 
-    const handleRowClick = (item) => {
-        setSelectedSymbol(item.common_symbol);
-        setIsDetailModalVisible(true);
-    };
+  const handleRowClick = (item) => {
+    setSelectedSymbol(item.common_symbol)
+    setIsDetailModalVisible(true)
+  }
 
-    // Column definitions
-    const columns = [
-        {
-            key: 'common_symbol',
-            label: 'Common Symbol',
-            _props: { className: 'fw-semibold' },
-        },
-        {
-            key: 'provider_count',
-            label: 'Provider/Broker Count',
-            _props: { className: 'text-center' },
-            _style: { width: '25%' },
-        },
-        {
-            key: 'actions',
-            label: 'Actions',
-            _style: { width: '15%' },
-            filter: false,
-            sorter: false,
-            _props: { className: 'text-center' },
-        }
-    ];
+  // Column definitions
+  const columns = [
+    {
+      key: 'common_symbol',
+      label: 'Common Symbol',
+      _props: { className: 'fw-semibold' },
+    },
+    {
+      key: 'provider_count',
+      label: 'Provider/Broker Count',
+      _props: { className: 'text-center' },
+      _style: { width: '25%' },
+    },
+    {
+      key: 'actions',
+      label: 'Actions',
+      _style: { width: '15%' },
+      filter: false,
+      sorter: false,
+      _props: { className: 'text-center' },
+    },
+  ]
 
-    // Scoped column renderers
-    const scopedColumns = {
-        common_symbol: (item) => (
-            <td>
-                <strong 
-                    className="text-primary" 
-                    style={{ cursor: 'pointer' }}
-                    onClick={() => handleRowClick(item)}
-                >
-                    {item.common_symbol}
-                </strong>
-            </td>
-        ),
-        provider_count: (item) => (
-            <td className="text-center">
-                <CBadge color="info" className="fs-6">
-                    {item.provider_count}
-                </CBadge>
-            </td>
-        ),
-        actions: (item) => (
-            <td className="text-center">
-                <CButton
-                    variant="ghost"
-                    color="primary"
-                    size="sm"
-                    onClick={() => handleRowClick(item)}
-                    title="View Details"
-                >
-                    <CIcon icon={cilZoom} />
-                </CButton>
-            </td>
-        ),
-    };
+  // Scoped column renderers
+  const scopedColumns = {
+    common_symbol: (item) => (
+      <td>
+        <strong
+          className="text-primary"
+          style={{ cursor: 'pointer' }}
+          onClick={() => handleRowClick(item)}
+        >
+          {item.common_symbol}
+        </strong>
+      </td>
+    ),
+    provider_count: (item) => (
+      <td className="text-center">
+        <CBadge color="info" className="fs-6">
+          {item.provider_count}
+        </CBadge>
+      </td>
+    ),
+    actions: (item) => (
+      <td className="text-center">
+        <CButton
+          variant="ghost"
+          color="primary"
+          size="sm"
+          onClick={() => handleRowClick(item)}
+          title="View Details"
+        >
+          <CIcon icon={cilZoom} />
+        </CButton>
+      </td>
+    ),
+  }
 
-    return (
-        <>
-            <CRow>
-                <CCol xs={12}>
-                    <CCard>
-                        <CCardHeader>
-                            <CRow className="align-items-center">
-                                <CCol xs={6} md={8} xl={9} className="text-start">
-                                    <h5>Common Symbols</h5>
-                                </CCol>
-                                <CCol xs={6} md={4} xl={3} className="text-end">
-                                    <small className="text-muted">
-                                        {totalItems} total symbols
-                                    </small>
-                                </CCol>
-                            </CRow>
-                        </CCardHeader>
-                        <CCardBody>
-                            {/* Search Input */}
-                            <CRow className="mb-3">
-                                <CCol xs={12} md={6}>
-                                    <CInputGroup>
-                                        <CInputGroupText>
-                                            <CIcon icon={cilSearch} />
-                                        </CInputGroupText>
-                                        <CFormInput
-                                            type="text"
-                                            placeholder="Search common symbols..."
-                                            value={searchInput}
-                                            onChange={(e) => setSearchInput(e.target.value)}
-                                        />
-                                    </CInputGroup>
-                                </CCol>
-                            </CRow>
-
-                            {error && <CAlert color="danger">{error}</CAlert>}
-
-                            <CSmartTable
-                                items={items}
-                                columns={columns}
-                                loading={loading}
-                                itemsPerPage={itemsPerPage}
-                                pagination={false}
-                                columnSorter={{ external: true, resetable: true }}
-                                onSorterChange={handleSorterChange}
-                                sorterValue={{ column: sorter.column, state: sorter.direction }}
-                                clickableRows
-                                onRowClick={handleRowClick}
-                                scopedColumns={scopedColumns}
-                                tableProps={{
-                                    striped: true,
-                                    hover: true,
-                                    responsive: true,
-                                }}
-                            />
-
-                            {/* Pagination Controls */}
-                            <CRow className="mt-3 align-items-center justify-content-center">
-                                {totalPages > 1 && (
-                                    <CCol xs="auto">
-                                        <CSmartPagination
-                                            activePage={activePage}
-                                            pages={totalPages}
-                                            onActivePageChange={setActivePage}
-                                        />
-                                    </CCol>
-                                )}
-                                <CCol xs="auto" className="me-2">
-                                    <label htmlFor="itemsPerPageSelect" className="col-form-label">
-                                        Items per page:
-                                    </label>
-                                </CCol>
-                                <CCol xs="auto">
-                                    <CFormSelect
-                                        id="itemsPerPageSelect"
-                                        value={itemsPerPage}
-                                        onChange={handleItemsPerPageChange}
-                                        options={[
-                                            { label: '10', value: 10 },
-                                            { label: '25', value: 25 },
-                                            { label: '50', value: 50 },
-                                            { label: '100', value: 100 },
-                                        ]}
-                                    />
-                                </CCol>
-                            </CRow>
-                        </CCardBody>
-                    </CCard>
+  return (
+    <>
+      <CRow>
+        <CCol xs={12}>
+          <CCard>
+            <CCardHeader>
+              <CRow className="align-items-center">
+                <CCol xs={6} md={8} xl={9} className="text-start">
+                  <h5>Common Symbols</h5>
                 </CCol>
-            </CRow>
+                <CCol xs={6} md={4} xl={3} className="text-end">
+                  <small className="text-muted">{totalItems} total symbols</small>
+                </CCol>
+              </CRow>
+            </CCardHeader>
+            <CCardBody>
+              {/* Search Input */}
+              <CRow className="mb-3">
+                <CCol xs={12} md={6}>
+                  <CInputGroup>
+                    <CInputGroupText>
+                      <CIcon icon={cilSearch} />
+                    </CInputGroupText>
+                    <CFormInput
+                      type="text"
+                      placeholder="Search common symbols..."
+                      value={searchInput}
+                      onChange={(e) => setSearchInput(e.target.value)}
+                    />
+                  </CInputGroup>
+                </CCol>
+              </CRow>
 
-            {/* Detail Modal */}
-            <CommonSymbolDetailModal
-                visible={isDetailModalVisible}
-                onClose={() => {
-                    setIsDetailModalVisible(false);
-                    setSelectedSymbol(null);
-                }}
-                onRenameSuccess={() => {
-                    setIsDetailModalVisible(false);
-                    setSelectedSymbol(null);
-                    fetchData();
-                }}
-                commonSymbol={selectedSymbol}
-            />
-        </>
-    );
-};
+              {error && <CAlert color="danger">{error}</CAlert>}
 
-export default CommonSymbolsTab;
+              <CSmartTable
+                items={items}
+                columns={columns}
+                loading={loading}
+                itemsPerPage={itemsPerPage}
+                pagination={false}
+                columnSorter={{ external: true, resetable: true }}
+                onSorterChange={handleSorterChange}
+                sorterValue={{ column: sorter.column, state: sorter.direction }}
+                clickableRows
+                onRowClick={handleRowClick}
+                scopedColumns={scopedColumns}
+                tableProps={{
+                  striped: true,
+                  hover: true,
+                  responsive: true,
+                }}
+              />
+
+              {/* Pagination Controls */}
+              <CRow className="mt-3 align-items-center justify-content-center">
+                {totalPages > 1 && (
+                  <CCol xs="auto">
+                    <CSmartPagination
+                      activePage={activePage}
+                      pages={totalPages}
+                      onActivePageChange={setActivePage}
+                    />
+                  </CCol>
+                )}
+                <CCol xs="auto" className="me-2">
+                  <label htmlFor="itemsPerPageSelect" className="col-form-label">
+                    Items per page:
+                  </label>
+                </CCol>
+                <CCol xs="auto">
+                  <CFormSelect
+                    id="itemsPerPageSelect"
+                    value={itemsPerPage}
+                    onChange={handleItemsPerPageChange}
+                    options={[
+                      { label: '10', value: 10 },
+                      { label: '25', value: 25 },
+                      { label: '50', value: 50 },
+                      { label: '100', value: 100 },
+                    ]}
+                  />
+                </CCol>
+              </CRow>
+            </CCardBody>
+          </CCard>
+        </CCol>
+      </CRow>
+
+      {/* Detail Modal */}
+      <CommonSymbolDetailModal
+        visible={isDetailModalVisible}
+        onClose={() => {
+          setIsDetailModalVisible(false)
+          setSelectedSymbol(null)
+        }}
+        onRenameSuccess={() => {
+          setIsDetailModalVisible(false)
+          setSelectedSymbol(null)
+          fetchData()
+        }}
+        commonSymbol={selectedSymbol}
+      />
+    </>
+  )
+}
+
+export default CommonSymbolsTab

--- a/web/src/views/mappings/MappingAddModal.js
+++ b/web/src/views/mappings/MappingAddModal.js
@@ -1,19 +1,29 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect } from 'react'
 import {
-  CModal, CModalHeader, CModalTitle, CModalBody, CModalFooter,
-  CButton, CForm, CRow, CCol, CFormLabel, CFormSelect, CFormInput,
-  CSpinner
-} from '@coreui/react-pro';
-import CIcon from '@coreui/icons-react';
-import { cilArrowRight } from '@coreui/icons';
-import AsyncSelect from 'react-select/async'; // For asynchronous server-side search
-import AsyncCreatableSelect from 'react-select/async-creatable'; // For async search with create option
-import { 
+  CModal,
+  CModalHeader,
+  CModalTitle,
+  CModalBody,
+  CModalFooter,
+  CButton,
+  CForm,
+  CRow,
+  CCol,
+  CFormLabel,
+  CFormSelect,
+  CFormInput,
+  CSpinner,
+} from '@coreui/react-pro'
+import CIcon from '@coreui/icons-react'
+import { cilArrowRight } from '@coreui/icons'
+import AsyncSelect from 'react-select/async' // For asynchronous server-side search
+import AsyncCreatableSelect from 'react-select/async-creatable' // For async search with create option
+import {
   getAssets,
   getRegisteredClasses,
   createAssetMapping,
   getAssetMappings,
-} from '../services/registry_api';  
+} from '../services/registry_api'
 
 // Format option label for custom display in dropdown and selected value
 const formatOptionLabel = (data, { context }) => {
@@ -22,73 +32,71 @@ const formatOptionLabel = (data, { context }) => {
     return (
       <div>
         <div style={{ fontWeight: 'bold' }}>{data.symbol}</div>
-        <div style={{ fontSize: '0.85em', opacity: 0.7 }}>
-          {data.name}
-        </div>
+        <div style={{ fontSize: '0.85em', opacity: 0.7 }}>{data.name}</div>
       </div>
-    );
+    )
   }
   // Selected value display
   return (
     <span>
       {data.symbol} <span style={{ fontSize: '0.9em', opacity: 0.7 }}>({data.name})</span>
     </span>
-  );
-};
-
+  )
+}
 
 const MappingAddModal = ({ visible, onClose, onSuccess, pushToast }) => {
-  const [fromClassName, setFromClassName] = useState('');
+  const [fromClassName, setFromClassName] = useState('')
   // For react-select, the value is an object or null
-  const [fromClassSymbol, setFromClassSymbol] = useState(null);
+  const [fromClassSymbol, setFromClassSymbol] = useState(null)
   // For common symbol, using react-select format (object with value/label) or string for new values
-  const [toCommonSymbol, setToCommonSymbol] = useState(null);
+  const [toCommonSymbol, setToCommonSymbol] = useState(null)
 
-  const [isLoadingSymbols, setIsLoadingSymbols] = useState(false);
-  const [isLoadingCommonSymbols, setIsLoadingCommonSymbols] = useState(false);
+  const [isLoadingSymbols, setIsLoadingSymbols] = useState(false)
+  const [isLoadingCommonSymbols, setIsLoadingCommonSymbols] = useState(false)
 
   // State for loading class names
-  const [classData, setClassData] = useState([]);
-  const [isLoadingClassData, setIsLoadingClassData] = useState(false);
-  const [errorClassData, setErrorClassData] = useState(null);
+  const [classData, setClassData] = useState([])
+  const [isLoadingClassData, setIsLoadingClassData] = useState(false)
+  const [errorClassData, setErrorClassData] = useState(null)
 
   // State for saving
-  const [isSaving, setIsSaving] = useState(false);
-  const [saveError, setSaveError] = useState(null);
+  const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState(null)
 
   useEffect(() => {
     if (visible) {
-      setFromClassName("");
-      setFromClassSymbol(null);
-      setToCommonSymbol(null);
-      setErrorClassData(null);
-      setClassData([]);
-      setSaveError(null);
+      setFromClassName('')
+      setFromClassSymbol(null)
+      setToCommonSymbol(null)
+      setErrorClassData(null)
+      setClassData([])
+      setSaveError(null)
 
       const fetchClassNames = async () => {
-        setIsLoadingClassData(true);
+        setIsLoadingClassData(true)
         try {
-          const data = await getRegisteredClasses();
-          setClassData(data || []);
+          const data = await getRegisteredClasses()
+          setClassData(data || [])
         } catch (error) {
-          console.error("Error fetching class names:", error);
-          setErrorClassData(error.message);
+          console.error('Error fetching class names:', error)
+          setErrorClassData(error.message)
         } finally {
-          setIsLoadingClassData(false);
+          setIsLoadingClassData(false)
         }
       }
-      fetchClassNames();
+      fetchClassNames()
     }
-  }, [visible]); // Fetch class names when modal opens
+  }, [visible]) // Fetch class names when modal opens
 
   // This function will be called by AsyncSelect to load options
   const loadSymbolOptions = useCallback(
     async (inputValue, callback) => {
-      if (!fromClassName || inputValue.length < 1) { // Don't search if no class or input is too short
-        callback([]);
-        return;
+      if (!fromClassName || inputValue.length < 1) {
+        // Don't search if no class or input is too short
+        callback([])
+        return
       }
-      setIsLoadingSymbols(true);
+      setIsLoadingSymbols(true)
       try {
         const params = {
           class_name_like: fromClassName,
@@ -96,106 +104,106 @@ const MappingAddModal = ({ visible, onClose, onSuccess, pushToast }) => {
           // name_like: inputValue,
           limit: 50,
         }
-        console.log("Loading symbols with params:", params);
-        const assetData = await getAssets(params);
+        console.log('Loading symbols with params:', params)
+        const assetData = await getAssets(params)
 
         // Format the Options
-        const options = (assetData.items || []).map(item => ({
+        const options = (assetData.items || []).map((item) => ({
           value: item.symbol,
           label: `${item.symbol} (${item.name || 'N/A'})`,
           symbol: item.symbol,
           name: item.name || 'N/A',
-        }));
+        }))
 
-        callback(options);
+        callback(options)
       } catch (error) {
-        console.error("Error loading symbol options:", error);
-        callback([]); // Send empty array on error
+        console.error('Error loading symbol options:', error)
+        callback([]) // Send empty array on error
       } finally {
-        setIsLoadingSymbols(false);
+        setIsLoadingSymbols(false)
       }
     },
-    [fromClassName] // Dependency: re-create this function if fromClassName changes
-  );
+    [fromClassName], // Dependency: re-create this function if fromClassName changes
+  )
 
   // This function will be called by AsyncCreatableSelect to load existing common symbol options
   const loadCommonSymbolOptions = useCallback(
     async (inputValue, callback) => {
       if (inputValue.length < 1) {
         // Load some default options when input is empty
-        setIsLoadingCommonSymbols(true);
+        setIsLoadingCommonSymbols(true)
         try {
-          const mappings = await getAssetMappings();
+          const mappings = await getAssetMappings()
           // Extract unique common symbols
-          const uniqueSymbols = [...new Set(mappings.map(m => m.common_symbol))].sort();
-          const options = uniqueSymbols.map(symbol => ({
+          const uniqueSymbols = [...new Set(mappings.map((m) => m.common_symbol))].sort()
+          const options = uniqueSymbols.map((symbol) => ({
             value: symbol,
             label: symbol,
-          }));
-          callback(options);
+          }))
+          callback(options)
         } catch (error) {
-          console.error("Error loading common symbol options:", error);
-          callback([]);
+          console.error('Error loading common symbol options:', error)
+          callback([])
         } finally {
-          setIsLoadingCommonSymbols(false);
+          setIsLoadingCommonSymbols(false)
         }
-        return;
+        return
       }
 
       // Filter existing common symbols based on input
-      setIsLoadingCommonSymbols(true);
+      setIsLoadingCommonSymbols(true)
       try {
-        const mappings = await getAssetMappings();
+        const mappings = await getAssetMappings()
         // Filter common symbols that match the input (case-insensitive)
-        const filteredSymbols = [...new Set(mappings.map(m => m.common_symbol))]
-          .filter(symbol => symbol.toLowerCase().includes(inputValue.toLowerCase()))
-          .sort();
-        
-        const options = filteredSymbols.map(symbol => ({
+        const filteredSymbols = [...new Set(mappings.map((m) => m.common_symbol))]
+          .filter((symbol) => symbol.toLowerCase().includes(inputValue.toLowerCase()))
+          .sort()
+
+        const options = filteredSymbols.map((symbol) => ({
           value: symbol,
           label: symbol,
-        }));
-        callback(options);
+        }))
+        callback(options)
       } catch (error) {
-        console.error("Error loading common symbol options:", error);
-        callback([]);
+        console.error('Error loading common symbol options:', error)
+        callback([])
       } finally {
-        setIsLoadingCommonSymbols(false);
+        setIsLoadingCommonSymbols(false)
       }
     },
-    [] // No dependencies - loads all mappings
-  );
+    [], // No dependencies - loads all mappings
+  )
 
   const handleFromClassNameChange = (e) => {
-    setFromClassName(e.target.value);
-    setFromClassSymbol(null); // Reset symbol when class name changes
-  };
+    setFromClassName(e.target.value)
+    setFromClassSymbol(null) // Reset symbol when class name changes
+  }
 
   const handleSave = async () => {
     // Validate required fields
     if (!fromClassName || !fromClassSymbol || !toCommonSymbol) {
-      setSaveError("Please fill in all required fields.");
-      return;
+      setSaveError('Please fill in all required fields.')
+      return
     }
 
     // Extract common symbol value from react-select option object
     // AsyncCreatableSelect always provides an object with { value, label } format
-    const commonSymbolValue = toCommonSymbol.value ? toCommonSymbol.value.trim() : null;
-    
+    const commonSymbolValue = toCommonSymbol.value ? toCommonSymbol.value.trim() : null
+
     if (!commonSymbolValue) {
-      setSaveError("Common symbol cannot be empty.");
-      return;
+      setSaveError('Common symbol cannot be empty.')
+      return
     }
 
     // Find the class type from classData
-    const selectedClass = classData.find(cls => cls.class_name === fromClassName);
+    const selectedClass = classData.find((cls) => cls.class_name === fromClassName)
     if (!selectedClass) {
-      setSaveError("Selected class not found.");
-      return;
+      setSaveError('Selected class not found.')
+      return
     }
 
-    const classType = selectedClass.class_type;
-    const classSymbol = fromClassSymbol.value;
+    const classType = selectedClass.class_type
+    const classSymbol = fromClassSymbol.value
 
     // Build the request payload
     const mappingData = {
@@ -204,45 +212,46 @@ const MappingAddModal = ({ visible, onClose, onSuccess, pushToast }) => {
       class_type: classType,
       class_symbol: classSymbol,
       is_active: true,
-    };
+    }
 
-    setIsSaving(true);
-    setSaveError(null);
+    setIsSaving(true)
+    setSaveError(null)
 
     try {
-      const created = await createAssetMapping(mappingData);
-      const createdMapping = Array.isArray(created) ? created[0] : created;
+      const created = await createAssetMapping(mappingData)
+      const createdMapping = Array.isArray(created) ? created[0] : created
       if (!createdMapping) {
-        throw new Error("Failed to create mapping");
+        throw new Error('Failed to create mapping')
       }
       // Success - close modal and refresh parent list
       if (onSuccess) {
-        onSuccess();
+        onSuccess()
       }
-      onClose();
+      onClose()
     } catch (error) {
-      console.error("Error creating asset mapping:", error);
+      console.error('Error creating asset mapping:', error)
       if (pushToast) {
         pushToast({
-          title: "Create mapping failed",
-          body: error.message || "Failed to create mapping. Please try again.",
-          color: "danger",
-        });
+          title: 'Create mapping failed',
+          body: error.message || 'Failed to create mapping. Please try again.',
+          color: 'danger',
+        })
       } else {
-        setSaveError(error.message || "Failed to create mapping. Please try again.");
+        setSaveError(error.message || 'Failed to create mapping. Please try again.')
       }
     } finally {
-      setIsSaving(false);
+      setIsSaving(false)
     }
-  };
-
+  }
 
   return (
     <CModal visible={visible} onClose={onClose} backdrop="static" size="lg">
       <CModalHeader onClose={onClose}>
         <CModalTitle>Create New Asset Mapping (Basic)</CModalTitle>
       </CModalHeader>
-      <CForm onSubmit={(e) => e.preventDefault()}> {/* Prevent default form submission */}
+      <CForm onSubmit={(e) => e.preventDefault()}>
+        {' '}
+        {/* Prevent default form submission */}
         <CModalBody>
           <CRow>
             {/* "FROM" Side */}
@@ -257,9 +266,13 @@ const MappingAddModal = ({ visible, onClose, onSuccess, pushToast }) => {
                     onChange={handleFromClassNameChange}
                     disabled={isLoadingClassData}
                   >
-                      <option value="" disabled>Select Class Name</option>
-                    {classData.map(opt => (
-                      <option key={opt.class_name} value={opt.class_name}>{opt.class_name}</option>
+                    <option value="" disabled>
+                      Select Class Name
+                    </option>
+                    {classData.map((opt) => (
+                      <option key={opt.class_name} value={opt.class_name}>
+                        {opt.class_name}
+                      </option>
                     ))}
                   </CFormSelect>
                 </CCol>
@@ -282,9 +295,9 @@ const MappingAddModal = ({ visible, onClose, onSuccess, pushToast }) => {
                     formatOptionLabel={formatOptionLabel}
                     classNamePrefix="themed-select"
                     noOptionsMessage={({ inputValue }) =>
-                        !inputValue ? "Type to search..." : "No symbols found"
+                      !inputValue ? 'Type to search...' : 'No symbols found'
                     }
-                    loadingMessage={() => "Loading symbols..."}
+                    loadingMessage={() => 'Loading symbols...'}
                   />
                 </CCol>
               </CRow>
@@ -314,9 +327,11 @@ const MappingAddModal = ({ visible, onClose, onSuccess, pushToast }) => {
                     isClearable
                     formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
                     noOptionsMessage={({ inputValue }) =>
-                      !inputValue ? "Type to search or create..." : `No matches found. Press Enter to create "${inputValue}"`
+                      !inputValue
+                        ? 'Type to search or create...'
+                        : `No matches found. Press Enter to create "${inputValue}"`
                     }
-                    loadingMessage={() => "Loading common symbols..."}
+                    loadingMessage={() => 'Loading common symbols...'}
                     classNamePrefix="themed-select"
                   />
                 </CCol>
@@ -337,7 +352,11 @@ const MappingAddModal = ({ visible, onClose, onSuccess, pushToast }) => {
           <CButton color="secondary" onClick={onClose} disabled={isSaving}>
             Cancel
           </CButton>
-          <CButton color="primary" onClick={handleSave} disabled={!fromClassName || !fromClassSymbol || !toCommonSymbol || isSaving}>
+          <CButton
+            color="primary"
+            onClick={handleSave}
+            disabled={!fromClassName || !fromClassSymbol || !toCommonSymbol || isSaving}
+          >
             {isSaving ? (
               <>
                 <CSpinner size="sm" className="me-2" />
@@ -350,7 +369,7 @@ const MappingAddModal = ({ visible, onClose, onSuccess, pushToast }) => {
         </CModalFooter>
       </CForm>
     </CModal>
-  );
-};
+  )
+}
 
-export default MappingAddModal;
+export default MappingAddModal

--- a/web/src/views/mappings/MappingAddModal.js
+++ b/web/src/views/mappings/MappingAddModal.js
@@ -104,7 +104,6 @@ const MappingAddModal = ({ visible, onClose, onSuccess, pushToast }) => {
           // name_like: inputValue,
           limit: 50,
         }
-        console.log('Loading symbols with params:', params)
         const assetData = await getAssets(params)
 
         // Format the Options

--- a/web/src/views/mappings/MappingEditModal.js
+++ b/web/src/views/mappings/MappingEditModal.js
@@ -1,26 +1,33 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect } from 'react'
 import {
-  CModal, CModalHeader, CModalTitle, CModalBody, CModalFooter,
-  CButton, CForm, CRow, CCol, CFormLabel, CFormInput, CFormCheck,
-  CSpinner
-} from '@coreui/react-pro';
-import AsyncCreatableSelect from 'react-select/async-creatable';
-import { 
-  getAssetMappings,
-  updateAssetMapping,
-} from '../services/registry_api';  
+  CModal,
+  CModalHeader,
+  CModalTitle,
+  CModalBody,
+  CModalFooter,
+  CButton,
+  CForm,
+  CRow,
+  CCol,
+  CFormLabel,
+  CFormInput,
+  CFormCheck,
+  CSpinner,
+} from '@coreui/react-pro'
+import AsyncCreatableSelect from 'react-select/async-creatable'
+import { getAssetMappings, updateAssetMapping } from '../services/registry_api'
 
 const MappingEditModal = ({ visible, onClose, onSuccess, mapping }) => {
   // State for editable fields
-  const [commonSymbol, setCommonSymbol] = useState(null);
-  const [isActive, setIsActive] = useState(true);
+  const [commonSymbol, setCommonSymbol] = useState(null)
+  const [isActive, setIsActive] = useState(true)
 
   // State for loading common symbols
-  const [isLoadingCommonSymbols, setIsLoadingCommonSymbols] = useState(false);
+  const [isLoadingCommonSymbols, setIsLoadingCommonSymbols] = useState(false)
 
   // State for saving
-  const [isSaving, setIsSaving] = useState(false);
-  const [saveError, setSaveError] = useState(null);
+  const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState(null)
 
   // Initialize form when modal opens or mapping changes
   useEffect(() => {
@@ -29,107 +36,107 @@ const MappingEditModal = ({ visible, onClose, onSuccess, mapping }) => {
       setCommonSymbol({
         value: mapping.common_symbol,
         label: mapping.common_symbol,
-      });
-      setIsActive(mapping.is_active);
-      setSaveError(null);
+      })
+      setIsActive(mapping.is_active)
+      setSaveError(null)
     }
-  }, [visible, mapping]);
+  }, [visible, mapping])
 
   // This function will be called by AsyncCreatableSelect to load existing common symbol options
   const loadCommonSymbolOptions = useCallback(
     async (inputValue, callback) => {
       if (inputValue.length < 1) {
         // Load some default options when input is empty
-        setIsLoadingCommonSymbols(true);
+        setIsLoadingCommonSymbols(true)
         try {
-          const mappings = await getAssetMappings();
+          const mappings = await getAssetMappings()
           // Extract unique common symbols
-          const uniqueSymbols = [...new Set(mappings.map(m => m.common_symbol))].sort();
-          const options = uniqueSymbols.map(symbol => ({
+          const uniqueSymbols = [...new Set(mappings.map((m) => m.common_symbol))].sort()
+          const options = uniqueSymbols.map((symbol) => ({
             value: symbol,
             label: symbol,
-          }));
-          callback(options);
+          }))
+          callback(options)
         } catch (error) {
-          console.error("Error loading common symbol options:", error);
-          callback([]);
+          console.error('Error loading common symbol options:', error)
+          callback([])
         } finally {
-          setIsLoadingCommonSymbols(false);
+          setIsLoadingCommonSymbols(false)
         }
-        return;
+        return
       }
 
       // Filter existing common symbols based on input
-      setIsLoadingCommonSymbols(true);
+      setIsLoadingCommonSymbols(true)
       try {
-        const mappings = await getAssetMappings();
+        const mappings = await getAssetMappings()
         // Filter common symbols that match the input (case-insensitive)
-        const filteredSymbols = [...new Set(mappings.map(m => m.common_symbol))]
-          .filter(symbol => symbol.toLowerCase().includes(inputValue.toLowerCase()))
-          .sort();
-        
-        const options = filteredSymbols.map(symbol => ({
+        const filteredSymbols = [...new Set(mappings.map((m) => m.common_symbol))]
+          .filter((symbol) => symbol.toLowerCase().includes(inputValue.toLowerCase()))
+          .sort()
+
+        const options = filteredSymbols.map((symbol) => ({
           value: symbol,
           label: symbol,
-        }));
-        callback(options);
+        }))
+        callback(options)
       } catch (error) {
-        console.error("Error loading common symbol options:", error);
-        callback([]);
+        console.error('Error loading common symbol options:', error)
+        callback([])
       } finally {
-        setIsLoadingCommonSymbols(false);
+        setIsLoadingCommonSymbols(false)
       }
     },
-    [] // No dependencies - loads all mappings
-  );
+    [], // No dependencies - loads all mappings
+  )
 
   const handleSave = async () => {
     // Validate required fields
     if (!mapping || !commonSymbol) {
-      setSaveError("Common symbol is required.");
-      return;
+      setSaveError('Common symbol is required.')
+      return
     }
 
     // Extract common symbol value from react-select option object
-    const commonSymbolValue = commonSymbol.value ? commonSymbol.value.trim() : null;
-    
+    const commonSymbolValue = commonSymbol.value ? commonSymbol.value.trim() : null
+
     if (!commonSymbolValue) {
-      setSaveError("Common symbol cannot be empty.");
-      return;
+      setSaveError('Common symbol cannot be empty.')
+      return
     }
 
     // Build the update payload (only fields that can be updated)
     const updateData = {
       common_symbol: commonSymbolValue,
       is_active: isActive,
-    };
+    }
 
-    setIsSaving(true);
-    setSaveError(null);
+    setIsSaving(true)
+    setSaveError(null)
 
     try {
       await updateAssetMapping(
         mapping.class_name,
         mapping.class_type,
         mapping.class_symbol,
-        updateData
-      );
+        updateData,
+      )
       // Success - close modal and refresh parent list
       if (onSuccess) {
-        onSuccess();
+        onSuccess()
       }
-      onClose();
+      onClose()
     } catch (error) {
-      console.error("Error updating asset mapping:", error);
-      setSaveError(error.message || "Failed to update mapping. Please try again.");
+      console.error('Error updating asset mapping:', error)
+      setSaveError(error.message || 'Failed to update mapping. Please try again.')
     } finally {
-      setIsSaving(false);
+      setIsSaving(false)
     }
-  };
+  }
 
   // Don't render if no mapping provided
   if (!mapping) {
-    return null;
+    return null
   }
 
   return (
@@ -199,10 +206,12 @@ const MappingEditModal = ({ visible, onClose, onSuccess, mapping }) => {
                     isLoading={isLoadingCommonSymbols}
                     isClearable
                     formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
-                    noOptionsMessage={({ inputValue }) => 
-                      !inputValue ? "Type to search or create..." : `No matches found. Press Enter to create "${inputValue}"`
+                    noOptionsMessage={({ inputValue }) =>
+                      !inputValue
+                        ? 'Type to search or create...'
+                        : `No matches found. Press Enter to create "${inputValue}"`
                     }
-                    loadingMessage={() => "Loading common symbols..."}
+                    loadingMessage={() => 'Loading common symbols...'}
                     classNamePrefix="themed-select"
                   />
                 </CCol>
@@ -248,8 +257,7 @@ const MappingEditModal = ({ visible, onClose, onSuccess, mapping }) => {
         </CModalFooter>
       </CForm>
     </CModal>
-  );
-};
+  )
+}
 
-export default MappingEditModal;
-
+export default MappingEditModal

--- a/web/src/views/mappings/Mappings.js
+++ b/web/src/views/mappings/Mappings.js
@@ -40,6 +40,9 @@ import {
   getRegisteredClasses,
 } from '../services/registry_api'
 
+// Utils
+import { getClassBadge, getActiveBadge } from '../../utils/badgeHelpers'
+
 // Asset class options for filtering (matches backend enums.py)
 const ASSET_CLASS_OPTIONS = [
   { label: 'All Asset Classes', value: '' },
@@ -250,23 +253,6 @@ const Mappings = () => {
       _props: { className: 'text-center' },
     },
   ]
-
-  const getClassBadge = (class_type) => {
-    switch (class_type) {
-      case 'provider': {
-        return 'primary'
-      }
-      case 'broker': {
-        return 'secondary'
-      }
-      default: {
-        return 'primary'
-      }
-    }
-  }
-  const getActiveBadge = (is_active) => {
-    return is_active ? 'success' : 'danger'
-  }
 
   const handleDelete = async (item) => {
     // Confirm deletion

--- a/web/src/views/mappings/Mappings.js
+++ b/web/src/views/mappings/Mappings.js
@@ -43,19 +43,19 @@ import {
 // Utils
 import { getClassBadge, getActiveBadge } from '../../utils/badgeHelpers'
 
-// Asset class options for filtering (matches backend enums.py)
+// Enums
+import { ASSET_CLASSES } from '../../enums'
+
+// Generate asset class options from enum (matches backend enums.py)
+const formatLabel = (value) => {
+  if (!value) return ''
+  const withSpaces = value.replace(/_/g, ' ')
+  return withSpaces.charAt(0).toUpperCase() + withSpaces.slice(1)
+}
+
 const ASSET_CLASS_OPTIONS = [
   { label: 'All Asset Classes', value: '' },
-  { label: 'Equity', value: 'equity' },
-  { label: 'Fund', value: 'fund' },
-  { label: 'ETF', value: 'etf' },
-  { label: 'Bond', value: 'bond' },
-  { label: 'Crypto', value: 'crypto' },
-  { label: 'Currency', value: 'currency' },
-  { label: 'Future', value: 'future' },
-  { label: 'Option', value: 'option' },
-  { label: 'Index', value: 'index' },
-  { label: 'Commodity', value: 'commodity' },
+  ...ASSET_CLASSES.map((ac) => ({ value: ac, label: formatLabel(ac) })),
 ]
 
 const Mappings = () => {

--- a/web/src/views/mappings/Mappings.js
+++ b/web/src/views/mappings/Mappings.js
@@ -31,6 +31,8 @@ import MappingAddModal from './MappingAddModal';
 import MappingEditModal from './MappingEditModal';
 // Suggest Mappings Modal
 import SuggestMappingsModal from './SuggestMappingsModal';
+// Re-map Confirm Modal
+import RemapConfirmModal from './RemapConfirmModal';
 // Common Symbols Tab
 import CommonSymbolsTab from './CommonSymbolsTab';
 
@@ -88,6 +90,13 @@ const Mappings = () => {
 
   // Get text filter keys for mappings (columns that support LIKE filtering)
   const textInputFilterKeys = useMemo(() => ['common_symbol', 'class_symbol', 'class_name'], []);
+
+  // Derive class_type for the selected provider filter
+  const selectedProviderClassType = useMemo(() => {
+    if (!providerFilter) return '';
+    const selected = providerOptions.find(opt => opt.value === providerFilter);
+    return selected?.class_type || 'provider';
+  }, [providerFilter, providerOptions]);
 
   const pushToast = ({ title, body, color = 'danger', icon = null }) => {
     const toast = (
@@ -517,6 +526,18 @@ const Mappings = () => {
           fetchMappings();
         }}
         pushToast={pushToast}
+      />
+      <RemapConfirmModal
+        visible={isRemapModalVisible}
+        onClose={() => setIsRemapModalVisible(false)}
+        onConfirm={(result) => {
+          // Success handling will be added in T033
+          setActivePage(1);
+          fetchMappings();
+        }}
+        providerFilter={providerFilter}
+        providerClassType={selectedProviderClassType}
+        assetClassFilter={assetClassFilter}
       />
     </>
   );

--- a/web/src/views/mappings/Mappings.js
+++ b/web/src/views/mappings/Mappings.js
@@ -364,45 +364,52 @@ const Mappings = () => {
                     <CButton color="success" onClick={() => setIsSuggestModalVisible(true)}>
                       Suggest Mappings
                     </CButton>
-                    <CButton color="warning" onClick={() => setIsRemapModalVisible(true)}>
-                      Re-map Filtered
-                    </CButton>
                   </CCol>
                 </CRow>
               </CCardHeader>
               <CCardBody>
-                {/* Filter Row */}
-                <CRow className="mb-3 align-items-center">
-                  <CCol xs="auto">
-                    <label htmlFor="assetClassFilter" className="col-form-label">
-                      Asset Class:
-                    </label>
-                  </CCol>
-                  <CCol xs="auto">
-                    <CFormSelect
-                      id="assetClassFilter"
-                      value={assetClassFilter}
-                      onChange={handleAssetClassFilterChange}
-                      options={ASSET_CLASS_OPTIONS}
-                      style={{ minWidth: '180px' }}
-                    />
-                  </CCol>
-                  <CCol xs="auto">
-                    <label htmlFor="providerFilter" className="col-form-label">
-                      Provider:
-                    </label>
-                  </CCol>
-                  <CCol xs="auto">
-                    <CFormSelect
-                      id="providerFilter"
-                      value={providerFilter}
-                      onChange={handleProviderFilterChange}
-                      options={providerOptions}
-                      disabled={isLoadingProviders}
-                      style={{ minWidth: '200px' }}
-                    />
-                  </CCol>
-                </CRow>
+                {/* Filter Box with Re-map Button */}
+                <div
+                  className="mb-3 p-3 rounded border"
+                  style={{ backgroundColor: 'var(--cui-tertiary-bg)' }}
+                >
+                  <CRow className="align-items-center g-2">
+                    <CCol xs="auto">
+                      <label htmlFor="assetClassFilter" className="col-form-label">
+                        Asset Class:
+                      </label>
+                    </CCol>
+                    <CCol xs="auto">
+                      <CFormSelect
+                        id="assetClassFilter"
+                        value={assetClassFilter}
+                        onChange={handleAssetClassFilterChange}
+                        options={ASSET_CLASS_OPTIONS}
+                        style={{ minWidth: '180px' }}
+                      />
+                    </CCol>
+                    <CCol xs="auto">
+                      <label htmlFor="providerFilter" className="col-form-label">
+                        Provider:
+                      </label>
+                    </CCol>
+                    <CCol xs="auto">
+                      <CFormSelect
+                        id="providerFilter"
+                        value={providerFilter}
+                        onChange={handleProviderFilterChange}
+                        options={providerOptions}
+                        disabled={isLoadingProviders}
+                        style={{ minWidth: '200px' }}
+                      />
+                    </CCol>
+                    <CCol xs="auto" className="ms-auto">
+                      <CButton color="warning" onClick={() => setIsRemapModalVisible(true)}>
+                        Re-map Filtered
+                      </CButton>
+                    </CCol>
+                  </CRow>
+                </div>
                 <CSmartTable
                   loading={loading}
                   items={mappings}

--- a/web/src/views/mappings/Mappings.js
+++ b/web/src/views/mappings/Mappings.js
@@ -20,9 +20,10 @@ import {
     CNavLink,
 } from '@coreui/react-pro';
 import CIcon from '@coreui/icons-react'
-import { 
+import {
     cilTrash,
     cilPencil,
+    cilCheckCircle,
 } from '@coreui/icons'
 
 // Add Mapping Modal
@@ -531,7 +532,18 @@ const Mappings = () => {
         visible={isRemapModalVisible}
         onClose={() => setIsRemapModalVisible(false)}
         onConfirm={(result) => {
-          // Success handling will be added in T033
+          // Show success toast with deleted/created counts
+          const toastBody =
+            result.status === 'no_mappings'
+              ? 'No mappings matched the filters.'
+              : `Deleted ${result.deleted_mappings} mapping${result.deleted_mappings !== 1 ? 's' : ''}, created ${result.created_mappings} mapping${result.created_mappings !== 1 ? 's' : ''}.`;
+          pushToast({
+            title: 'Re-map Completed',
+            body: toastBody,
+            color: 'success',
+            icon: cilCheckCircle,
+          });
+          // Refresh mappings list
           setActivePage(1);
           fetchMappings();
         }}

--- a/web/src/views/mappings/Mappings.js
+++ b/web/src/views/mappings/Mappings.js
@@ -40,6 +40,21 @@ import {
     deleteAssetMapping,
 } from '../services/registry_api';
 
+// Asset class options for filtering (matches backend enums.py)
+const ASSET_CLASS_OPTIONS = [
+  { label: 'All Asset Classes', value: '' },
+  { label: 'Equity', value: 'equity' },
+  { label: 'Fund', value: 'fund' },
+  { label: 'ETF', value: 'etf' },
+  { label: 'Bond', value: 'bond' },
+  { label: 'Crypto', value: 'crypto' },
+  { label: 'Currency', value: 'currency' },
+  { label: 'Future', value: 'future' },
+  { label: 'Option', value: 'option' },
+  { label: 'Index', value: 'index' },
+  { label: 'Commodity', value: 'commodity' },
+];
+
 const Mappings = () => {
   // State
   const [mappings, setMappings] = useState([]);
@@ -54,6 +69,9 @@ const Mappings = () => {
 
   // Tab state
   const [activeTab, setActiveTab] = useState('mappings');
+
+  // Asset class filter state for re-map functionality
+  const [assetClassFilter, setAssetClassFilter] = useState('');
 
   // Pagination state
   const [totalItems, setTotalItems] = useState(0);
@@ -106,6 +124,11 @@ const Mappings = () => {
       }
     }
 
+    // Add asset class filter if set
+    if (assetClassFilter) {
+      apiParams.asset_class = assetClassFilter;
+    }
+
     try {
       const data = await getAssetMappings(apiParams);
       setMappings(data.items || []);
@@ -146,7 +169,7 @@ const Mappings = () => {
       setError(null);
       fetchMappings();
     }
-  }, [activeTab, activePage, itemsPerPage, sorter, columnFilter]);
+  }, [activeTab, activePage, itemsPerPage, sorter, columnFilter, assetClassFilter]);
 
   // Define columns for CSmartTable
   const columns = [
@@ -219,6 +242,11 @@ const Mappings = () => {
     const newSize = parseInt(event.target.value, 10);
     setActivePage(1); // Reset to first page when changing page size
     setItemsPerPage(newSize);
+  };
+
+  const handleAssetClassFilterChange = (event) => {
+    setActivePage(1); // Reset to first page when changing filter
+    setAssetClassFilter(event.target.value);
   };
 
   const handleSorterChange = (sorterData) => {
@@ -294,6 +322,21 @@ const Mappings = () => {
                 </CRow>
               </CCardHeader>
               <CCardBody>
+                {/* Asset Class Filter Row */}
+                <CRow className="mb-3 align-items-center">
+                  <CCol xs="auto">
+                    <label htmlFor="assetClassFilter" className="col-form-label">Asset Class:</label>
+                  </CCol>
+                  <CCol xs="auto">
+                    <CFormSelect
+                      id="assetClassFilter"
+                      value={assetClassFilter}
+                      onChange={handleAssetClassFilterChange}
+                      options={ASSET_CLASS_OPTIONS}
+                      style={{ minWidth: '180px' }}
+                    />
+                  </CCol>
+                </CRow>
                 <CSmartTable
                   loading={loading}
                   items={mappings}

--- a/web/src/views/mappings/Mappings.js
+++ b/web/src/views/mappings/Mappings.js
@@ -1,4 +1,4 @@
-import { React, useState, useEffect, useRef, useMemo } from 'react'
+import { React, useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import {
   CCard,
   CCardBody,
@@ -109,7 +109,7 @@ const Mappings = () => {
   }
 
   // Fetch Mappings
-  const fetchMappings = async () => {
+  const fetchMappings = useCallback(async () => {
     setLoading(true)
     setError(null)
 
@@ -156,7 +156,15 @@ const Mappings = () => {
     } finally {
       setLoading(false)
     }
-  }
+  }, [
+    itemsPerPage,
+    activePage,
+    sorter,
+    columnFilter,
+    assetClassFilter,
+    providerFilter,
+    textInputFilterKeys,
+  ])
 
   // useEffect for debouncing live text input filters
   useEffect(() => {
@@ -212,7 +220,7 @@ const Mappings = () => {
       setError(null)
       fetchMappings()
     }
-  }, [activeTab, activePage, itemsPerPage, sorter, columnFilter, assetClassFilter, providerFilter])
+  }, [activeTab, fetchMappings])
 
   // Define columns for CSmartTable
   const columns = [

--- a/web/src/views/mappings/Mappings.js
+++ b/web/src/views/mappings/Mappings.js
@@ -1,48 +1,44 @@
-﻿import { React, useState, useEffect, useRef, useMemo } from 'react';
+import { React, useState, useEffect, useRef, useMemo } from 'react'
 import {
-    CCard,
-    CCardBody,
-    CCardHeader,
-    CCol,
-    CRow,
-    CSmartTable,
-    CSmartPagination,
-    CFormSelect,
-    CAlert,
-    CButton,
-    CBadge,
-    CToaster,
-    CToast,
-    CToastHeader,
-    CToastBody,
-    CNav,
-    CNavItem,
-    CNavLink,
-} from '@coreui/react-pro';
+  CCard,
+  CCardBody,
+  CCardHeader,
+  CCol,
+  CRow,
+  CSmartTable,
+  CSmartPagination,
+  CFormSelect,
+  CAlert,
+  CButton,
+  CBadge,
+  CToaster,
+  CToast,
+  CToastHeader,
+  CToastBody,
+  CNav,
+  CNavItem,
+  CNavLink,
+} from '@coreui/react-pro'
 import CIcon from '@coreui/icons-react'
-import {
-    cilTrash,
-    cilPencil,
-    cilCheckCircle,
-} from '@coreui/icons'
+import { cilTrash, cilPencil, cilCheckCircle } from '@coreui/icons'
 
 // Add Mapping Modal
-import MappingAddModal from './MappingAddModal';
+import MappingAddModal from './MappingAddModal'
 // Edit Mapping Modal
-import MappingEditModal from './MappingEditModal';
+import MappingEditModal from './MappingEditModal'
 // Suggest Mappings Modal
-import SuggestMappingsModal from './SuggestMappingsModal';
+import SuggestMappingsModal from './SuggestMappingsModal'
 // Re-map Confirm Modal
-import RemapConfirmModal from './RemapConfirmModal';
+import RemapConfirmModal from './RemapConfirmModal'
 // Common Symbols Tab
-import CommonSymbolsTab from './CommonSymbolsTab';
+import CommonSymbolsTab from './CommonSymbolsTab'
 
 // API Imports
 import {
-    getAssetMappings,
-    deleteAssetMapping,
-    getRegisteredClasses,
-} from '../services/registry_api';
+  getAssetMappings,
+  deleteAssetMapping,
+  getRegisteredClasses,
+} from '../services/registry_api'
 
 // Asset class options for filtering (matches backend enums.py)
 const ASSET_CLASS_OPTIONS = [
@@ -57,47 +53,47 @@ const ASSET_CLASS_OPTIONS = [
   { label: 'Option', value: 'option' },
   { label: 'Index', value: 'index' },
   { label: 'Commodity', value: 'commodity' },
-];
+]
 
 const Mappings = () => {
   // State
-  const [mappings, setMappings] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [isAddModalVisible, setIsAddModalVisible] = useState(false);
-  const [isEditModalVisible, setIsEditModalVisible] = useState(false);
-  const [isSuggestModalVisible, setIsSuggestModalVisible] = useState(false);
-  const [isRemapModalVisible, setIsRemapModalVisible] = useState(false);
-  const [currentMapping, setCurrentMapping] = useState(null);
-  const [toastToShow, setToastToShow] = useState(null);
-  const toasterRef = useRef(null);
+  const [mappings, setMappings] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [isAddModalVisible, setIsAddModalVisible] = useState(false)
+  const [isEditModalVisible, setIsEditModalVisible] = useState(false)
+  const [isSuggestModalVisible, setIsSuggestModalVisible] = useState(false)
+  const [isRemapModalVisible, setIsRemapModalVisible] = useState(false)
+  const [currentMapping, setCurrentMapping] = useState(null)
+  const [toastToShow, setToastToShow] = useState(null)
+  const toasterRef = useRef(null)
 
   // Tab state
-  const [activeTab, setActiveTab] = useState('mappings');
+  const [activeTab, setActiveTab] = useState('mappings')
 
   // Filter states for re-map functionality
-  const [assetClassFilter, setAssetClassFilter] = useState('');
-  const [providerFilter, setProviderFilter] = useState('');
-  const [providerOptions, setProviderOptions] = useState([]);
-  const [isLoadingProviders, setIsLoadingProviders] = useState(false);
+  const [assetClassFilter, setAssetClassFilter] = useState('')
+  const [providerFilter, setProviderFilter] = useState('')
+  const [providerOptions, setProviderOptions] = useState([])
+  const [isLoadingProviders, setIsLoadingProviders] = useState(false)
 
   // Pagination state
-  const [totalItems, setTotalItems] = useState(0);
-  const [activePage, setActivePage] = useState(1);
-  const [itemsPerPage, setItemsPerPage] = useState(10);
-  const [sorter, setSorter] = useState({});
-  const [columnFilter, setColumnFilter] = useState({});
-  const [liveTextInputFilters, setLiveTextInputFilters] = useState({});
+  const [totalItems, setTotalItems] = useState(0)
+  const [activePage, setActivePage] = useState(1)
+  const [itemsPerPage, setItemsPerPage] = useState(10)
+  const [sorter, setSorter] = useState({})
+  const [columnFilter, setColumnFilter] = useState({})
+  const [liveTextInputFilters, setLiveTextInputFilters] = useState({})
 
   // Get text filter keys for mappings (columns that support LIKE filtering)
-  const textInputFilterKeys = useMemo(() => ['common_symbol', 'class_symbol', 'class_name'], []);
+  const textInputFilterKeys = useMemo(() => ['common_symbol', 'class_symbol', 'class_name'], [])
 
   // Derive class_type for the selected provider filter
   const selectedProviderClassType = useMemo(() => {
-    if (!providerFilter) return '';
-    const selected = providerOptions.find(opt => opt.value === providerFilter);
-    return selected?.class_type || 'provider';
-  }, [providerFilter, providerOptions]);
+    if (!providerFilter) return ''
+    const selected = providerOptions.find((opt) => opt.value === providerFilter)
+    return selected?.class_type || 'provider'
+  }, [providerFilter, providerOptions])
 
   const pushToast = ({ title, body, color = 'danger', icon = null }) => {
     const toast = (
@@ -108,119 +104,124 @@ const Mappings = () => {
         </CToastHeader>
         <CToastBody>{body}</CToastBody>
       </CToast>
-    );
-    setToastToShow(toast);
-  };
+    )
+    setToastToShow(toast)
+  }
 
   // Fetch Mappings
   const fetchMappings = async () => {
-    setLoading(true);
-    setError(null);
+    setLoading(true)
+    setError(null)
 
     const apiParams = {
       limit: itemsPerPage,
       offset: (activePage - 1) * itemsPerPage,
-    };
+    }
 
     // Add sorting parameters
     if (sorter && sorter.column) {
-      apiParams.sort_by = sorter.column;
-      apiParams.sort_order = sorter.direction || 'asc';
+      apiParams.sort_by = sorter.column
+      apiParams.sort_order = sorter.direction || 'asc'
     }
 
     // Add filter parameters
     for (const key in columnFilter) {
       if (columnFilter[key]) {
         if (textInputFilterKeys.includes(key)) {
-          apiParams[`${key}_like`] = columnFilter[key];
+          apiParams[`${key}_like`] = columnFilter[key]
         } else {
-          apiParams[key] = columnFilter[key];
+          apiParams[key] = columnFilter[key]
         }
       }
     }
 
     // Add asset class filter if set
     if (assetClassFilter) {
-      apiParams.asset_class = assetClassFilter;
+      apiParams.asset_class = assetClassFilter
     }
 
     // Add provider filter if set
     if (providerFilter) {
-      apiParams.class_name = providerFilter;
+      apiParams.class_name = providerFilter
     }
 
     try {
-      const data = await getAssetMappings(apiParams);
-      setMappings(data.items || []);
-      setTotalItems(data.total_items || 0);
+      const data = await getAssetMappings(apiParams)
+      setMappings(data.items || [])
+      setTotalItems(data.total_items || 0)
     } catch (err) {
-      setError(err.message || 'Failed to fetch mappings');
-      setMappings([]);
-      setTotalItems(0);
+      setError(err.message || 'Failed to fetch mappings')
+      setMappings([])
+      setTotalItems(0)
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  };
+  }
 
   // useEffect for debouncing live text input filters
   useEffect(() => {
     const handler = setTimeout(() => {
-      setColumnFilter(prevMainFilters => {
-        const newMainFilters = { ...prevMainFilters };
+      setColumnFilter((prevMainFilters) => {
+        const newMainFilters = { ...prevMainFilters }
 
-        textInputFilterKeys.forEach(key => {
+        textInputFilterKeys.forEach((key) => {
           if (liveTextInputFilters[key]) {
-            newMainFilters[key] = liveTextInputFilters[key];
+            newMainFilters[key] = liveTextInputFilters[key]
           } else {
-            delete newMainFilters[key];
+            delete newMainFilters[key]
           }
-        });
-        return newMainFilters;
-      });
-    }, 300); // 300ms debounce
+        })
+        return newMainFilters
+      })
+    }, 300) // 300ms debounce
 
     return () => {
-      clearTimeout(handler);
-    };
-  }, [liveTextInputFilters, textInputFilterKeys]);
+      clearTimeout(handler)
+    }
+  }, [liveTextInputFilters, textInputFilterKeys])
 
   // Fetch provider options on mount
   useEffect(() => {
     const fetchProviders = async () => {
-      setIsLoadingProviders(true);
+      setIsLoadingProviders(true)
       try {
-        const data = await getRegisteredClasses();
+        const data = await getRegisteredClasses()
         // Transform to dropdown options with "All Providers" default
         const options = [
           { label: 'All Providers', value: '' },
-          ...(data || []).map(cls => ({
+          ...(data || []).map((cls) => ({
             label: `${cls.class_name} (${cls.class_type})`,
             value: cls.class_name,
             class_type: cls.class_type,
           })),
-        ];
-        setProviderOptions(options);
+        ]
+        setProviderOptions(options)
       } catch (err) {
-        console.error('Error fetching providers:', err);
+        console.error('Error fetching providers:', err)
         // Still set default option on error
-        setProviderOptions([{ label: 'All Providers', value: '' }]);
+        setProviderOptions([{ label: 'All Providers', value: '' }])
       } finally {
-        setIsLoadingProviders(false);
+        setIsLoadingProviders(false)
       }
-    };
-    fetchProviders();
-  }, []);
+    }
+    fetchProviders()
+  }, [])
 
   useEffect(() => {
     if (activeTab === 'mappings') {
-      setError(null);
-      fetchMappings();
+      setError(null)
+      fetchMappings()
     }
-  }, [activeTab, activePage, itemsPerPage, sorter, columnFilter, assetClassFilter, providerFilter]);
+  }, [activeTab, activePage, itemsPerPage, sorter, columnFilter, assetClassFilter, providerFilter])
 
   // Define columns for CSmartTable
   const columns = [
-    { key: 'common_symbol', label: 'Common Symbol', _props: { className: 'fw-semibold' }, sorter: true },
+    {
+      key: 'common_symbol',
+      label: 'Common Symbol',
+      _props: { className: 'fw-semibold' },
+      sorter: true,
+    },
     { key: 'class_symbol', label: 'Class Symbol', sorter: true },
     { key: 'class_name', label: 'Class Name', sorter: true },
     { key: 'class_type', label: 'Class Type', sorter: true },
@@ -228,9 +229,9 @@ const Mappings = () => {
       key: 'is_active',
       label: 'Active',
       _style: { width: '10%' },
-      sorter: true,  // Enable server-side sorting
+      sorter: true, // Enable server-side sorting
       filter: false, // Keep filter disabled (boolean handled differently)
-      _props: { className: 'text-center' }
+      _props: { className: 'text-center' },
     },
     {
       key: 'actions',
@@ -239,9 +240,8 @@ const Mappings = () => {
       filter: false,
       sorter: false,
       _props: { className: 'text-center' },
-    }
+    },
   ]
-
 
   const getClassBadge = (class_type) => {
     switch (class_type) {
@@ -257,49 +257,49 @@ const Mappings = () => {
     }
   }
   const getActiveBadge = (is_active) => {
-    return is_active ? 'success' : 'danger';
+    return is_active ? 'success' : 'danger'
   }
 
   const handleDelete = async (item) => {
     // Confirm deletion
-    const confirmMessage = `Are you sure you want to delete the mapping for ${item.common_symbol} (${item.class_name}/${item.class_type})?`;
+    const confirmMessage = `Are you sure you want to delete the mapping for ${item.common_symbol} (${item.class_name}/${item.class_type})?`
     if (!window.confirm(confirmMessage)) {
-      return;
+      return
     }
 
     try {
-      await deleteAssetMapping(item.class_name, item.class_type, item.class_symbol);
+      await deleteAssetMapping(item.class_name, item.class_type, item.class_symbol)
       // Refresh list after successful deletion
-      await fetchMappings();
+      await fetchMappings()
     } catch (err) {
-      setError(err.message || 'Failed to delete mapping');
-      alert(`Error deleting mapping: ${err.message}`);
+      setError(err.message || 'Failed to delete mapping')
+      alert(`Error deleting mapping: ${err.message}`)
     }
-  };
+  }
 
   const handleEdit = (item) => {
-    setCurrentMapping(item);
-    setIsEditModalVisible(true);
-  };
+    setCurrentMapping(item)
+    setIsEditModalVisible(true)
+  }
   const handleAdd = () => {
-    setIsAddModalVisible(true);
+    setIsAddModalVisible(true)
   }
 
   const handleItemsPerPageChange = (event) => {
-    const newSize = parseInt(event.target.value, 10);
-    setActivePage(1); // Reset to first page when changing page size
-    setItemsPerPage(newSize);
-  };
+    const newSize = parseInt(event.target.value, 10)
+    setActivePage(1) // Reset to first page when changing page size
+    setItemsPerPage(newSize)
+  }
 
   const handleAssetClassFilterChange = (event) => {
-    setActivePage(1); // Reset to first page when changing filter
-    setAssetClassFilter(event.target.value);
-  };
+    setActivePage(1) // Reset to first page when changing filter
+    setAssetClassFilter(event.target.value)
+  }
 
   const handleProviderFilterChange = (event) => {
-    setActivePage(1); // Reset to first page when changing filter
-    setProviderFilter(event.target.value);
-  };
+    setActivePage(1) // Reset to first page when changing filter
+    setProviderFilter(event.target.value)
+  }
 
   const handleSorterChange = (sorterData) => {
     // CSmartTable provides SorterValue: { column: string, state: 'asc' | 'desc' | 0 }
@@ -307,26 +307,26 @@ const Mappings = () => {
 
     if (!sorterData) {
       // No sorting - clear state
-      setSorter({});
-      setActivePage(1);
-      return;
+      setSorter({})
+      setActivePage(1)
+      return
     }
 
     // Handle single sorter (non-multiple mode)
     if (sorterData.column && sorterData.state !== 0) {
       setSorter({
         column: sorterData.column,
-        direction: sorterData.state  // Map 'state' to 'direction' for API
-      });
-      setActivePage(1); // Reset to first page when sorting changes
+        direction: sorterData.state, // Map 'state' to 'direction' for API
+      })
+      setActivePage(1) // Reset to first page when sorting changes
     } else {
       // State is 0 (cleared) or invalid
-      setSorter({});
-      setActivePage(1);
+      setSorter({})
+      setActivePage(1)
     }
-  };
+  }
 
-  const calculatedPages = totalItems > 0 ? Math.ceil(totalItems / itemsPerPage) : 1;
+  const calculatedPages = totalItems > 0 ? Math.ceil(totalItems / itemsPerPage) : 1
 
   return (
     <>
@@ -380,7 +380,9 @@ const Mappings = () => {
                 {/* Filter Row */}
                 <CRow className="mb-3 align-items-center">
                   <CCol xs="auto">
-                    <label htmlFor="assetClassFilter" className="col-form-label">Asset Class:</label>
+                    <label htmlFor="assetClassFilter" className="col-form-label">
+                      Asset Class:
+                    </label>
                   </CCol>
                   <CCol xs="auto">
                     <CFormSelect
@@ -392,7 +394,9 @@ const Mappings = () => {
                     />
                   </CCol>
                   <CCol xs="auto">
-                    <label htmlFor="providerFilter" className="col-form-label">Provider:</label>
+                    <label htmlFor="providerFilter" className="col-form-label">
+                      Provider:
+                    </label>
                   </CCol>
                   <CCol xs="auto">
                     <CFormSelect
@@ -409,10 +413,10 @@ const Mappings = () => {
                   loading={loading}
                   items={mappings}
                   columns={columns}
-                  pagination={false}  // Disable built-in pagination
-                  columnSorter={{ external: true, resetable: true }}  // External sorting
-                  onSorterChange={handleSorterChange}  // Custom sorter handler
-                  columnFilter  // Enable filtering
+                  pagination={false} // Disable built-in pagination
+                  columnSorter={{ external: true, resetable: true }} // External sorting
+                  onSorterChange={handleSorterChange} // Custom sorter handler
+                  columnFilter // Enable filtering
                   columnFilterValue={liveTextInputFilters}
                   onColumnFilterChange={setLiveTextInputFilters}
                   scopedColumns={{
@@ -462,7 +466,11 @@ const Mappings = () => {
                   }}
                 />
 
-                {error && <CAlert color="danger" className="mb-3">{error}</CAlert>}
+                {error && (
+                  <CAlert color="danger" className="mb-3">
+                    {error}
+                  </CAlert>
+                )}
 
                 <CRow className="mb-3 align-items-center justify-content-center">
                   {calculatedPages > 1 && (
@@ -475,7 +483,9 @@ const Mappings = () => {
                     </CCol>
                   )}
                   <CCol xs="auto" className="me-2">
-                    <label htmlFor="itemsPerPageSelect" className="col-form-label">Items per page:</label>
+                    <label htmlFor="itemsPerPageSelect" className="col-form-label">
+                      Items per page:
+                    </label>
                   </CCol>
                   <CCol xs="auto">
                     <CFormSelect
@@ -502,20 +512,20 @@ const Mappings = () => {
         visible={isAddModalVisible}
         onClose={() => setIsAddModalVisible(false)}
         onSuccess={() => {
-          setActivePage(1); // Reset to first page after add
-          fetchMappings();
+          setActivePage(1) // Reset to first page after add
+          fetchMappings()
         }}
         pushToast={pushToast}
       />
       <MappingEditModal
         visible={isEditModalVisible}
         onClose={() => {
-          setIsEditModalVisible(false);
-          setCurrentMapping(null);
+          setIsEditModalVisible(false)
+          setCurrentMapping(null)
         }}
         onSuccess={() => {
-          setActivePage(1); // Reset to first page after edit
-          fetchMappings();
+          setActivePage(1) // Reset to first page after edit
+          fetchMappings()
         }}
         mapping={currentMapping}
       />
@@ -523,8 +533,8 @@ const Mappings = () => {
         visible={isSuggestModalVisible}
         onClose={() => setIsSuggestModalVisible(false)}
         onSuccess={() => {
-          setActivePage(1); // Reset to first page after suggest
-          fetchMappings();
+          setActivePage(1) // Reset to first page after suggest
+          fetchMappings()
         }}
         pushToast={pushToast}
       />
@@ -536,23 +546,23 @@ const Mappings = () => {
           const toastBody =
             result.status === 'no_mappings'
               ? 'No mappings matched the filters.'
-              : `Deleted ${result.deleted_mappings} mapping${result.deleted_mappings !== 1 ? 's' : ''}, created ${result.created_mappings} mapping${result.created_mappings !== 1 ? 's' : ''}.`;
+              : `Deleted ${result.deleted_mappings} mapping${result.deleted_mappings !== 1 ? 's' : ''}, created ${result.created_mappings} mapping${result.created_mappings !== 1 ? 's' : ''}.`
           pushToast({
             title: 'Re-map Completed',
             body: toastBody,
             color: 'success',
             icon: cilCheckCircle,
-          });
+          })
           // Refresh mappings list
-          setActivePage(1);
-          fetchMappings();
+          setActivePage(1)
+          fetchMappings()
         }}
         providerFilter={providerFilter}
         providerClassType={selectedProviderClassType}
         assetClassFilter={assetClassFilter}
       />
     </>
-  );
+  )
 }
 
-export default Mappings;
+export default Mappings

--- a/web/src/views/mappings/Mappings.js
+++ b/web/src/views/mappings/Mappings.js
@@ -64,6 +64,7 @@ const Mappings = () => {
   const [isAddModalVisible, setIsAddModalVisible] = useState(false);
   const [isEditModalVisible, setIsEditModalVisible] = useState(false);
   const [isSuggestModalVisible, setIsSuggestModalVisible] = useState(false);
+  const [isRemapModalVisible, setIsRemapModalVisible] = useState(false);
   const [currentMapping, setCurrentMapping] = useState(null);
   const [toastToShow, setToastToShow] = useState(null);
   const toasterRef = useRef(null);
@@ -358,6 +359,9 @@ const Mappings = () => {
                     </CButton>
                     <CButton color="success" onClick={() => setIsSuggestModalVisible(true)}>
                       Suggest Mappings
+                    </CButton>
+                    <CButton color="warning" onClick={() => setIsRemapModalVisible(true)}>
+                      Re-map Filtered
                     </CButton>
                   </CCol>
                 </CRow>

--- a/web/src/views/mappings/RemapConfirmModal.js
+++ b/web/src/views/mappings/RemapConfirmModal.js
@@ -324,9 +324,28 @@ const RemapConfirmModal = ({
             Close
           </CButton>
         ) : remapError ? (
-          <CButton color="secondary" onClick={handleClose}>
-            Close
-          </CButton>
+          <>
+            <CButton color="secondary" onClick={handleClose} disabled={remapping}>
+              Close
+            </CButton>
+            <CButton
+              color="warning"
+              onClick={handleConfirm}
+              disabled={remapping}
+            >
+              {remapping ? (
+                <>
+                  <CSpinner size="sm" className="me-2" />
+                  Retrying...
+                </>
+              ) : (
+                <>
+                  <CIcon icon={cilSync} className="me-2" />
+                  Retry
+                </>
+              )}
+            </CButton>
+          </>
         ) : (
           <>
             <CButton color="secondary" onClick={handleClose} disabled={remapping}>

--- a/web/src/views/mappings/RemapConfirmModal.js
+++ b/web/src/views/mappings/RemapConfirmModal.js
@@ -192,6 +192,10 @@ const RemapConfirmModal = ({
                         </li>
                       ))}
                     </ul>
+                    <p className="mb-0 mt-2 small text-body-secondary">
+                      These indices reference common symbols that will have their mappings regenerated.
+                      Index composition will remain unchanged, but underlying asset mappings may differ.
+                    </p>
                   </div>
                 </div>
               )}

--- a/web/src/views/mappings/RemapConfirmModal.js
+++ b/web/src/views/mappings/RemapConfirmModal.js
@@ -132,7 +132,10 @@ const RemapConfirmModal = ({
         {remapError && !remapResult && (
           <div
             className="p-3 rounded mb-3"
-            style={{ backgroundColor: 'var(--cui-danger-bg-subtle)' }}
+            style={{
+              backgroundColor: 'var(--cui-danger-bg-subtle)',
+              color: 'var(--cui-danger-text-emphasis)',
+            }}
           >
             <div className="d-flex align-items-center mb-2">
               <CIcon
@@ -145,8 +148,8 @@ const RemapConfirmModal = ({
                 Re-map operation failed
               </span>
             </div>
-            <p className="mb-0 text-body-secondary">{remapError}</p>
-            <p className="mb-0 mt-2 small text-body-secondary">
+            <p className="mb-0">{remapError}</p>
+            <p className="mb-0 mt-2 small">
               The operation has been rolled back. No mappings were modified.
             </p>
           </div>
@@ -156,7 +159,10 @@ const RemapConfirmModal = ({
         {remapResult && (
           <div
             className="p-3 rounded mb-3"
-            style={{ backgroundColor: 'var(--cui-success-bg-subtle)' }}
+            style={{
+              backgroundColor: 'var(--cui-success-bg-subtle)',
+              color: 'var(--cui-success-text-emphasis)',
+            }}
           >
             <div className="d-flex align-items-center mb-3">
               <CIcon
@@ -171,28 +177,34 @@ const RemapConfirmModal = ({
             </div>
             <div className="row text-center">
               <div className="col-4">
-                <div className="fs-3 fw-bold text-danger">{remapResult.deleted_mappings}</div>
-                <div className="small text-body-secondary">Deleted</div>
+                <div className="fs-3 fw-bold" style={{ color: 'var(--cui-danger)' }}>
+                  {remapResult.deleted_mappings}
+                </div>
+                <div className="small">Deleted</div>
               </div>
               <div className="col-4">
-                <div className="fs-3 fw-bold text-success">{remapResult.created_mappings}</div>
-                <div className="small text-body-secondary">Created</div>
+                <div className="fs-3 fw-bold" style={{ color: 'var(--cui-success)' }}>
+                  {remapResult.created_mappings}
+                </div>
+                <div className="small">Created</div>
               </div>
               <div className="col-4">
-                <div className="fs-3 fw-bold text-warning">{remapResult.skipped_mappings}</div>
-                <div className="small text-body-secondary">Skipped</div>
+                <div className="fs-3 fw-bold" style={{ color: 'var(--cui-warning)' }}>
+                  {remapResult.skipped_mappings}
+                </div>
+                <div className="small">Skipped</div>
               </div>
             </div>
             {remapResult.failed_mappings > 0 && (
               <div className="mt-3 text-center">
-                <span className="text-danger fw-medium">
+                <span className="fw-medium" style={{ color: 'var(--cui-danger)' }}>
                   {remapResult.failed_mappings} mapping
                   {remapResult.failed_mappings !== 1 ? 's' : ''} failed to create
                 </span>
               </div>
             )}
             {remapResult.providers_affected && remapResult.providers_affected.length > 0 && (
-              <div className="mt-3 small text-body-secondary text-center">
+              <div className="mt-3 small text-center">
                 Providers: {remapResult.providers_affected.join(', ')}
               </div>
             )}

--- a/web/src/views/mappings/RemapConfirmModal.js
+++ b/web/src/views/mappings/RemapConfirmModal.js
@@ -238,6 +238,14 @@ const RemapConfirmModal = ({
               </CAlert>
             )}
 
+            {/* Warning when no filters selected */}
+            {preview && !loading && !providerFilter && !assetClassFilter && (
+              <CAlert color="danger" className="mb-3">
+                <strong>Warning:</strong> No filters selected. This will re-map ALL mappings across
+                all providers.
+              </CAlert>
+            )}
+
             {/* Preview data with filter summary and mappings count */}
             {preview && !loading && (
               <div className="mb-3">

--- a/web/src/views/mappings/RemapConfirmModal.js
+++ b/web/src/views/mappings/RemapConfirmModal.js
@@ -8,6 +8,7 @@ import {
   CModalFooter,
   CButton,
   CSpinner,
+  CAlert,
 } from '@coreui/react-pro'
 import CIcon from '@coreui/icons-react'
 import { cilSync, cilWarning, cilCheckCircle } from '@coreui/icons'
@@ -181,7 +182,7 @@ const RemapConfirmModal = ({
               <li>Asset Class: {assetClassFilter}</li>
             )}
             {!providerFilter && !assetClassFilter && (
-              <li className="text-warning">No filters - all mappings will be affected</li>
+              <li className="text-warning-emphasis">No filters - all mappings will be affected</li>
             )}
           </ul>
         </div>
@@ -196,9 +197,10 @@ const RemapConfirmModal = ({
 
         {/* Preview error */}
         {previewError && (
-          <div className="text-danger mb-3">
+          <CAlert color="danger" className="d-flex align-items-center mb-3">
+            <CIcon icon={cilWarning} className="me-2 flex-shrink-0" />
             Failed to load preview: {previewError}
-          </div>
+          </CAlert>
         )}
 
         {/* Preview data with filter summary and mappings count */}

--- a/web/src/views/mappings/RemapConfirmModal.js
+++ b/web/src/views/mappings/RemapConfirmModal.js
@@ -1,0 +1,85 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {
+  CModal,
+  CModalHeader,
+  CModalTitle,
+  CModalBody,
+  CModalFooter,
+  CButton,
+} from '@coreui/react-pro'
+import CIcon from '@coreui/icons-react'
+import { cilSync } from '@coreui/icons'
+
+/**
+ * RemapConfirmModal - Confirmation modal for re-mapping filtered asset mappings.
+ * Shows a preview of the re-map operation impact and allows the user to confirm or cancel.
+ */
+const RemapConfirmModal = ({
+  visible,
+  onClose,
+  onConfirm,
+  providerFilter,
+  providerClassType,
+  assetClassFilter,
+}) => {
+  return (
+    <CModal
+      visible={visible}
+      onClose={onClose}
+      backdrop="static"
+      size="lg"
+    >
+      <CModalHeader>
+        <CModalTitle>
+          <CIcon icon={cilSync} className="me-2" />
+          Confirm Re-map Operation
+        </CModalTitle>
+      </CModalHeader>
+      <CModalBody>
+        <p className="text-body-secondary">
+          This will delete existing mappings matching your filters and regenerate them.
+        </p>
+        <div className="mb-3">
+          <strong>Filters Applied:</strong>
+          <ul className="mb-0 mt-2">
+            {providerFilter && (
+              <li>Provider: {providerFilter} ({providerClassType || 'provider'})</li>
+            )}
+            {assetClassFilter && (
+              <li>Asset Class: {assetClassFilter}</li>
+            )}
+            {!providerFilter && !assetClassFilter && (
+              <li className="text-warning">No filters - all mappings will be affected</li>
+            )}
+          </ul>
+        </div>
+      </CModalBody>
+      <CModalFooter>
+        <CButton color="secondary" onClick={onClose}>
+          Cancel
+        </CButton>
+        <CButton color="warning" onClick={onConfirm}>
+          Confirm Re-map
+        </CButton>
+      </CModalFooter>
+    </CModal>
+  )
+}
+
+RemapConfirmModal.propTypes = {
+  visible: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  providerFilter: PropTypes.string,
+  providerClassType: PropTypes.string,
+  assetClassFilter: PropTypes.string,
+}
+
+RemapConfirmModal.defaultProps = {
+  providerFilter: '',
+  providerClassType: '',
+  assetClassFilter: '',
+}
+
+export default RemapConfirmModal

--- a/web/src/views/mappings/RemapConfirmModal.js
+++ b/web/src/views/mappings/RemapConfirmModal.js
@@ -170,6 +170,16 @@ const RemapConfirmModal = ({
                 </div>
               )}
 
+              {/* Providers affected list */}
+              {preview.providers_affected && preview.providers_affected.length > 0 && (
+                <div className="mt-2 small text-body-secondary">
+                  <span className="fw-medium">Providers affected: </span>
+                  <span className="text-body">
+                    {preview.providers_affected.join(', ')}
+                  </span>
+                </div>
+              )}
+
               {/* Affected indices display with warning styling */}
               {preview.affected_indices && preview.affected_indices.length > 0 && (
                 <div

--- a/web/src/views/mappings/RemapConfirmModal.js
+++ b/web/src/views/mappings/RemapConfirmModal.js
@@ -102,17 +102,16 @@ const RemapConfirmModal = ({
   }
 
   return (
-    <CModal
-      visible={visible}
-      onClose={handleClose}
-      backdrop="static"
-      size="lg"
-    >
+    <CModal visible={visible} onClose={handleClose} backdrop="static" size="lg">
       <CModalHeader>
         <CModalTitle>
           {remapResult ? (
             <>
-              <CIcon icon={cilCheckCircle} className="me-2" style={{ color: 'var(--cui-success)' }} />
+              <CIcon
+                icon={cilCheckCircle}
+                className="me-2"
+                style={{ color: 'var(--cui-success)' }}
+              />
               Re-map Complete
             </>
           ) : remapError ? (
@@ -146,9 +145,7 @@ const RemapConfirmModal = ({
                 Re-map operation failed
               </span>
             </div>
-            <p className="mb-0 text-body-secondary">
-              {remapError}
-            </p>
+            <p className="mb-0 text-body-secondary">{remapError}</p>
             <p className="mb-0 mt-2 small text-body-secondary">
               The operation has been rolled back. No mappings were modified.
             </p>
@@ -189,7 +186,8 @@ const RemapConfirmModal = ({
             {remapResult.failed_mappings > 0 && (
               <div className="mt-3 text-center">
                 <span className="text-danger fw-medium">
-                  {remapResult.failed_mappings} mapping{remapResult.failed_mappings !== 1 ? 's' : ''} failed to create
+                  {remapResult.failed_mappings} mapping
+                  {remapResult.failed_mappings !== 1 ? 's' : ''} failed to create
                 </span>
               </div>
             )}
@@ -207,114 +205,118 @@ const RemapConfirmModal = ({
             <p className="text-body-secondary">
               This will delete existing mappings matching your filters and regenerate them.
             </p>
-        <div className="mb-3">
-          <strong>Filters Applied:</strong>
-          <ul className="mb-0 mt-2">
-            {providerFilter && (
-              <li>Provider: {providerFilter} ({providerClassType || 'provider'})</li>
-            )}
-            {assetClassFilter && (
-              <li>Asset Class: {assetClassFilter}</li>
-            )}
-            {!providerFilter && !assetClassFilter && (
-              <li className="text-warning-emphasis">No filters - all mappings will be affected</li>
-            )}
-          </ul>
-        </div>
-
-        {/* Loading state */}
-        {loading && (
-          <div className="text-center py-3">
-            <CSpinner size="sm" className="me-2" />
-            <span className="text-body-secondary">Fetching preview...</span>
-          </div>
-        )}
-
-        {/* Preview error */}
-        {previewError && (
-          <CAlert color="danger" className="d-flex align-items-center mb-3">
-            <CIcon icon={cilWarning} className="me-2 flex-shrink-0" />
-            Failed to load preview: {previewError}
-          </CAlert>
-        )}
-
-        {/* Preview data with filter summary and mappings count */}
-        {preview && !loading && (
-          <div className="mb-3">
-            <strong>Impact Summary:</strong>
-            <div
-              className="mt-2 p-3 rounded"
-              style={{ backgroundColor: 'var(--cui-tertiary-bg)' }}
-            >
-              {/* Mappings count - prominently displayed */}
-              <div className="d-flex align-items-center mb-2">
-                <span className="fs-4 fw-semibold text-warning me-2">
-                  {preview.mappings_to_delete}
-                </span>
-                <span className="text-body-secondary">
-                  mapping{preview.mappings_to_delete !== 1 ? 's' : ''} will be deleted and regenerated
-                </span>
-              </div>
-
-              {/* Filter summary from server response */}
-              {preview.filter_applied && Object.keys(preview.filter_applied).length > 0 && (
-                <div className="small text-body-secondary">
-                  <span className="fw-medium">Filters: </span>
-                  {preview.filter_applied.class_name && (
-                    <span className="me-2">
-                      Provider: <span className="text-body">{preview.filter_applied.class_name}</span>
-                    </span>
-                  )}
-                  {preview.filter_applied.asset_class && (
-                    <span>
-                      Asset Class: <span className="text-body">{preview.filter_applied.asset_class}</span>
-                    </span>
-                  )}
-                </div>
-              )}
-
-              {/* Providers affected list */}
-              {preview.providers_affected && preview.providers_affected.length > 0 && (
-                <div className="mt-2 small text-body-secondary">
-                  <span className="fw-medium">Providers affected: </span>
-                  <span className="text-body">
-                    {preview.providers_affected.join(', ')}
-                  </span>
-                </div>
-              )}
-
-              {/* Affected indices display with warning styling */}
-              {preview.affected_indices && preview.affected_indices.length > 0 && (
-                <div
-                  className="mt-3 p-2 rounded d-flex align-items-start"
-                  style={{ backgroundColor: 'var(--cui-warning-bg-subtle)' }}
-                >
-                  <CIcon
-                    icon={cilWarning}
-                    className="me-2 flex-shrink-0"
-                    style={{ color: 'var(--cui-warning)' }}
-                  />
-                  <div>
-                    <span className="fw-medium" style={{ color: 'var(--cui-warning)' }}>
-                      Affected Indices:
-                    </span>
-                    <ul className="mb-0 mt-1 ps-3">
-                      {preview.affected_indices.map((indexName) => (
-                        <li key={indexName} className="text-body-secondary">
-                          {indexName}
-                        </li>
-                      ))}
-                    </ul>
-                    <p className="mb-0 mt-2 small text-body-secondary">
-                      These indices reference common symbols that will have their mappings regenerated.
-                      Index composition will remain unchanged, but underlying asset mappings may differ.
-                    </p>
-                  </div>
-                </div>
-              )}
+            <div className="mb-3">
+              <strong>Filters Applied:</strong>
+              <ul className="mb-0 mt-2">
+                {providerFilter && (
+                  <li>
+                    Provider: {providerFilter} ({providerClassType || 'provider'})
+                  </li>
+                )}
+                {assetClassFilter && <li>Asset Class: {assetClassFilter}</li>}
+                {!providerFilter && !assetClassFilter && (
+                  <li className="text-warning-emphasis">
+                    No filters - all mappings will be affected
+                  </li>
+                )}
+              </ul>
             </div>
-          </div>
-        )}
+
+            {/* Loading state */}
+            {loading && (
+              <div className="text-center py-3">
+                <CSpinner size="sm" className="me-2" />
+                <span className="text-body-secondary">Fetching preview...</span>
+              </div>
+            )}
+
+            {/* Preview error */}
+            {previewError && (
+              <CAlert color="danger" className="d-flex align-items-center mb-3">
+                <CIcon icon={cilWarning} className="me-2 flex-shrink-0" />
+                Failed to load preview: {previewError}
+              </CAlert>
+            )}
+
+            {/* Preview data with filter summary and mappings count */}
+            {preview && !loading && (
+              <div className="mb-3">
+                <strong>Impact Summary:</strong>
+                <div
+                  className="mt-2 p-3 rounded"
+                  style={{ backgroundColor: 'var(--cui-tertiary-bg)' }}
+                >
+                  {/* Mappings count - prominently displayed */}
+                  <div className="d-flex align-items-center mb-2">
+                    <span className="fs-4 fw-semibold text-warning me-2">
+                      {preview.mappings_to_delete}
+                    </span>
+                    <span className="text-body-secondary">
+                      mapping{preview.mappings_to_delete !== 1 ? 's' : ''} will be deleted and
+                      regenerated
+                    </span>
+                  </div>
+
+                  {/* Filter summary from server response */}
+                  {preview.filter_applied && Object.keys(preview.filter_applied).length > 0 && (
+                    <div className="small text-body-secondary">
+                      <span className="fw-medium">Filters: </span>
+                      {preview.filter_applied.class_name && (
+                        <span className="me-2">
+                          Provider:{' '}
+                          <span className="text-body">{preview.filter_applied.class_name}</span>
+                        </span>
+                      )}
+                      {preview.filter_applied.asset_class && (
+                        <span>
+                          Asset Class:{' '}
+                          <span className="text-body">{preview.filter_applied.asset_class}</span>
+                        </span>
+                      )}
+                    </div>
+                  )}
+
+                  {/* Providers affected list */}
+                  {preview.providers_affected && preview.providers_affected.length > 0 && (
+                    <div className="mt-2 small text-body-secondary">
+                      <span className="fw-medium">Providers affected: </span>
+                      <span className="text-body">{preview.providers_affected.join(', ')}</span>
+                    </div>
+                  )}
+
+                  {/* Affected indices display with warning styling */}
+                  {preview.affected_indices && preview.affected_indices.length > 0 && (
+                    <div
+                      className="mt-3 p-2 rounded d-flex align-items-start"
+                      style={{ backgroundColor: 'var(--cui-warning-bg-subtle)' }}
+                    >
+                      <CIcon
+                        icon={cilWarning}
+                        className="me-2 flex-shrink-0"
+                        style={{ color: 'var(--cui-warning)' }}
+                      />
+                      <div>
+                        <span className="fw-medium" style={{ color: 'var(--cui-warning)' }}>
+                          Affected Indices:
+                        </span>
+                        <ul className="mb-0 mt-1 ps-3">
+                          {preview.affected_indices.map((indexName) => (
+                            <li key={indexName} className="text-body-secondary">
+                              {indexName}
+                            </li>
+                          ))}
+                        </ul>
+                        <p className="mb-0 mt-2 small text-body-secondary">
+                          These indices reference common symbols that will have their mappings
+                          regenerated. Index composition will remain unchanged, but underlying asset
+                          mappings may differ.
+                        </p>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
           </>
         )}
       </CModalBody>
@@ -328,11 +330,7 @@ const RemapConfirmModal = ({
             <CButton color="secondary" onClick={handleClose} disabled={remapping}>
               Close
             </CButton>
-            <CButton
-              color="warning"
-              onClick={handleConfirm}
-              disabled={remapping}
-            >
+            <CButton color="warning" onClick={handleConfirm} disabled={remapping}>
               {remapping ? (
                 <>
                   <CSpinner size="sm" className="me-2" />

--- a/web/src/views/mappings/RemapConfirmModal.js
+++ b/web/src/views/mappings/RemapConfirmModal.js
@@ -109,13 +109,41 @@ const RemapConfirmModal = ({
           </div>
         )}
 
-        {/* Preview data placeholder - will be expanded in T030 */}
+        {/* Preview data with filter summary and mappings count */}
         {preview && !loading && (
           <div className="mb-3">
-            <strong>Preview:</strong>
-            <p className="text-body-secondary mt-2 mb-0">
-              {preview.mappings_to_delete} mapping(s) will be deleted and regenerated.
-            </p>
+            <strong>Impact Summary:</strong>
+            <div
+              className="mt-2 p-3 rounded"
+              style={{ backgroundColor: 'var(--cui-tertiary-bg)' }}
+            >
+              {/* Mappings count - prominently displayed */}
+              <div className="d-flex align-items-center mb-2">
+                <span className="fs-4 fw-semibold text-warning me-2">
+                  {preview.mappings_to_delete}
+                </span>
+                <span className="text-body-secondary">
+                  mapping{preview.mappings_to_delete !== 1 ? 's' : ''} will be deleted and regenerated
+                </span>
+              </div>
+
+              {/* Filter summary from server response */}
+              {preview.filter_applied && Object.keys(preview.filter_applied).length > 0 && (
+                <div className="small text-body-secondary">
+                  <span className="fw-medium">Filters: </span>
+                  {preview.filter_applied.class_name && (
+                    <span className="me-2">
+                      Provider: <span className="text-body">{preview.filter_applied.class_name}</span>
+                    </span>
+                  )}
+                  {preview.filter_applied.asset_class && (
+                    <span>
+                      Asset Class: <span className="text-body">{preview.filter_applied.asset_class}</span>
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
           </div>
         )}
       </CModalBody>

--- a/web/src/views/mappings/RemapConfirmModal.js
+++ b/web/src/views/mappings/RemapConfirmModal.js
@@ -10,7 +10,7 @@ import {
   CSpinner,
 } from '@coreui/react-pro'
 import CIcon from '@coreui/icons-react'
-import { cilSync } from '@coreui/icons'
+import { cilSync, cilWarning } from '@coreui/icons'
 import { getRemapPreview, remapAssetMappings } from '../services/registry_api'
 
 /**
@@ -167,6 +167,32 @@ const RemapConfirmModal = ({
                       Asset Class: <span className="text-body">{preview.filter_applied.asset_class}</span>
                     </span>
                   )}
+                </div>
+              )}
+
+              {/* Affected indices display with warning styling */}
+              {preview.affected_indices && preview.affected_indices.length > 0 && (
+                <div
+                  className="mt-3 p-2 rounded d-flex align-items-start"
+                  style={{ backgroundColor: 'var(--cui-warning-bg-subtle)' }}
+                >
+                  <CIcon
+                    icon={cilWarning}
+                    className="me-2 flex-shrink-0"
+                    style={{ color: 'var(--cui-warning)' }}
+                  />
+                  <div>
+                    <span className="fw-medium" style={{ color: 'var(--cui-warning)' }}>
+                      Affected Indices:
+                    </span>
+                    <ul className="mb-0 mt-1 ps-3">
+                      {preview.affected_indices.map((indexName) => (
+                        <li key={indexName} className="text-body-secondary">
+                          {indexName}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
                 </div>
               )}
             </div>

--- a/web/src/views/mappings/SuggestMappingsModal.js
+++ b/web/src/views/mappings/SuggestMappingsModal.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react'
 import {
   CModal,
   CModalHeader,
@@ -20,131 +20,135 @@ import {
   CTableBody,
   CTableDataCell,
   CBadge,
-} from '@coreui/react-pro';
-import CIcon from '@coreui/icons-react';
-import { cilArrowRight, cilWarning, cilLink } from '@coreui/icons';
-import { getRegisteredClasses, getAssetMappingSuggestions, createAssetMapping } from '../services/registry_api';
+} from '@coreui/react-pro'
+import CIcon from '@coreui/icons-react'
+import { cilArrowRight, cilWarning, cilLink } from '@coreui/icons'
+import {
+  getRegisteredClasses,
+  getAssetMappingSuggestions,
+  createAssetMapping,
+} from '../services/registry_api'
 
 const SuggestMappingsModal = ({ visible, onClose, onSuccess, pushToast }) => {
   // Dropdown selections
-  const [sourceClass, setSourceClass] = useState('');
-  const [targetClass, setTargetClass] = useState('');
+  const [sourceClass, setSourceClass] = useState('')
+  const [targetClass, setTargetClass] = useState('')
 
   // Class data from API
-  const [classData, setClassData] = useState([]);
-  const [isLoadingClasses, setIsLoadingClasses] = useState(false);
-  const [errorClasses, setErrorClasses] = useState(null);
+  const [classData, setClassData] = useState([])
+  const [isLoadingClasses, setIsLoadingClasses] = useState(false)
+  const [errorClasses, setErrorClasses] = useState(null)
 
   // Suggestions data
-  const [suggestions, setSuggestions] = useState([]);
-  const [isLoadingSuggestions, setIsLoadingSuggestions] = useState(false);
-  const [errorSuggestions, setErrorSuggestions] = useState(null);
+  const [suggestions, setSuggestions] = useState([])
+  const [isLoadingSuggestions, setIsLoadingSuggestions] = useState(false)
+  const [errorSuggestions, setErrorSuggestions] = useState(null)
 
   // Pagination
-  const [nextCursor, setNextCursor] = useState(null);
-  const [hasMore, setHasMore] = useState(false);
-  const [totalCount, setTotalCount] = useState(null);
+  const [nextCursor, setNextCursor] = useState(null)
+  const [hasMore, setHasMore] = useState(false)
+  const [totalCount, setTotalCount] = useState(null)
 
   // Editable common symbols and creation state
-  const [editedSymbols, setEditedSymbols] = useState({});
-  const [creatingRows, setCreatingRows] = useState({});
-  const [createdRows, setCreatedRows] = useState({});
+  const [editedSymbols, setEditedSymbols] = useState({})
+  const [creatingRows, setCreatingRows] = useState({})
+  const [createdRows, setCreatedRows] = useState({})
 
   // Search and filter state
-  const [searchTerm, setSearchTerm] = useState('');
-  const [debouncedSearch, setDebouncedSearch] = useState('');
-  const [minScoreFilter, setMinScoreFilter] = useState(30);
-  const [rowErrors, setRowErrors] = useState({});
+  const [searchTerm, setSearchTerm] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+  const [minScoreFilter, setMinScoreFilter] = useState(30)
+  const [rowErrors, setRowErrors] = useState({})
 
   // Helper function for score badge styling with proper contrast
   const getScoreBadgeStyle = (score) => {
     if (score >= 70) {
-      return { color: 'success', textColor: 'white' };  // Green - white text
+      return { color: 'success', textColor: 'white' } // Green - white text
     }
     if (score >= 50) {
-      return { color: 'warning', textColor: 'dark' };   // Yellow/Orange - dark text
+      return { color: 'warning', textColor: 'dark' } // Yellow/Orange - dark text
     }
-    return { color: 'secondary', textColor: 'white' };  // Grey - white text is fine for secondary
-  };
+    return { color: 'secondary', textColor: 'white' } // Grey - white text is fine for secondary
+  }
 
   // Helper for ID match badge styling
   const getIdMatchBadgeStyle = (isMatch) => {
     if (isMatch) {
-      return { color: 'success', textColor: 'white' };  // Green - white text
+      return { color: 'success', textColor: 'white' } // Green - white text
     }
-    return { color: 'light', textColor: 'dark' };       // Light grey - dark text for contrast
-  };
+    return { color: 'light', textColor: 'dark' } // Light grey - dark text for contrast
+  }
 
   // Debounce search input (400ms)
   useEffect(() => {
     const timer = setTimeout(() => {
-      setDebouncedSearch(searchTerm);
-    }, 400);
-    return () => clearTimeout(timer);
-  }, [searchTerm]);
+      setDebouncedSearch(searchTerm)
+    }, 400)
+    return () => clearTimeout(timer)
+  }, [searchTerm])
 
   // Fetch classes when modal opens
   useEffect(() => {
     if (visible) {
       // Reset all state when modal opens
-      setSourceClass('');
-      setTargetClass('');
-      setErrorClasses(null);
-      setClassData([]);
+      setSourceClass('')
+      setTargetClass('')
+      setErrorClasses(null)
+      setClassData([])
       // Reset suggestions state
-      setSuggestions([]);
-      setNextCursor(null);
-      setHasMore(false);
-      setTotalCount(null);
-      setErrorSuggestions(null);
+      setSuggestions([])
+      setNextCursor(null)
+      setHasMore(false)
+      setTotalCount(null)
+      setErrorSuggestions(null)
       // Reset editing state
-      setEditedSymbols({});
-      setCreatingRows({});
-      setCreatedRows({});
+      setEditedSymbols({})
+      setCreatingRows({})
+      setCreatedRows({})
       // Reset filters and errors
-      setSearchTerm('');
-      setDebouncedSearch('');
-      setMinScoreFilter(30);
-      setRowErrors({});
+      setSearchTerm('')
+      setDebouncedSearch('')
+      setMinScoreFilter(30)
+      setRowErrors({})
 
       const fetchClasses = async () => {
-        setIsLoadingClasses(true);
+        setIsLoadingClasses(true)
         try {
-          const data = await getRegisteredClasses();
-          setClassData(data || []);
+          const data = await getRegisteredClasses()
+          setClassData(data || [])
         } catch (error) {
-          console.error("Error fetching classes:", error);
-          setErrorClasses(error.message);
+          console.error('Error fetching classes:', error)
+          setErrorClasses(error.message)
         } finally {
-          setIsLoadingClasses(false);
+          setIsLoadingClasses(false)
         }
-      };
-      fetchClasses();
+      }
+      fetchClasses()
     }
-  }, [visible]);
+  }, [visible])
 
   // Fetch suggestions when source, target, or filters change
   useEffect(() => {
     if (sourceClass && targetClass) {
       // Reset suggestions state for new query
-      setSuggestions([]);
-      setNextCursor(null);
-      setHasMore(false);
-      setTotalCount(null);
-      setErrorSuggestions(null);
+      setSuggestions([])
+      setNextCursor(null)
+      setHasMore(false)
+      setTotalCount(null)
+      setErrorSuggestions(null)
       // Reset editing state
-      setEditedSymbols({});
-      setCreatingRows({});
-      setCreatedRows({});
-      setRowErrors({});
+      setEditedSymbols({})
+      setCreatingRows({})
+      setCreatedRows({})
+      setRowErrors({})
 
-      fetchSuggestions();
+      fetchSuggestions()
     }
-  }, [sourceClass, targetClass, debouncedSearch, minScoreFilter]);
+  }, [sourceClass, targetClass, debouncedSearch, minScoreFilter])
 
   const fetchSuggestions = async (cursor = null) => {
-    setIsLoadingSuggestions(true);
-    setErrorSuggestions(null);
+    setIsLoadingSuggestions(true)
+    setErrorSuggestions(null)
 
     try {
       const params = {
@@ -153,127 +157,125 @@ const SuggestMappingsModal = ({ visible, onClose, onSuccess, pushToast }) => {
         limit: 50,
         min_score: minScoreFilter,
         include_total: cursor === null, // Only get total on first fetch
-      };
+      }
       if (cursor) {
-        params.cursor = cursor;
+        params.cursor = cursor
       }
       if (debouncedSearch) {
-        params.search = debouncedSearch;
+        params.search = debouncedSearch
       }
 
-      const data = await getAssetMappingSuggestions(params);
+      const data = await getAssetMappingSuggestions(params)
 
       if (cursor) {
         // Append to existing suggestions
-        setSuggestions(prev => [...prev, ...data.items]);
+        setSuggestions((prev) => [...prev, ...data.items])
       } else {
         // Replace suggestions (first load)
-        setSuggestions(data.items || []);
+        setSuggestions(data.items || [])
         if (data.total !== null && data.total !== undefined) {
-          setTotalCount(data.total);
+          setTotalCount(data.total)
         }
       }
 
-      setNextCursor(data.next_cursor);
-      setHasMore(data.has_more);
+      setNextCursor(data.next_cursor)
+      setHasMore(data.has_more)
     } catch (error) {
-      console.error("Error fetching suggestions:", error);
-      setErrorSuggestions(error.message);
+      console.error('Error fetching suggestions:', error)
+      setErrorSuggestions(error.message)
     } finally {
-      setIsLoadingSuggestions(false);
+      setIsLoadingSuggestions(false)
     }
-  };
+  }
 
   const handleLoadMore = () => {
     if (nextCursor && !isLoadingSuggestions) {
-      fetchSuggestions(nextCursor);
+      fetchSuggestions(nextCursor)
     }
-  };
+  }
 
   // Handle source change - reset target if it matches new source
   const handleSourceChange = (e) => {
-    const newSource = e.target.value;
-    setSourceClass(newSource);
+    const newSource = e.target.value
+    setSourceClass(newSource)
     // Reset target if it was the same as new source
     if (targetClass === newSource) {
-      setTargetClass('');
+      setTargetClass('')
     }
     // Reset filters when source changes
-    setSearchTerm('');
-    setMinScoreFilter(30);
-    setRowErrors({});
-  };
+    setSearchTerm('')
+    setMinScoreFilter(30)
+    setRowErrors({})
+  }
 
   // Handle target change
   const handleTargetChange = (e) => {
-    setTargetClass(e.target.value);
+    setTargetClass(e.target.value)
     // Reset filters when target changes
-    setSearchTerm('');
-    setMinScoreFilter(30);
-    setRowErrors({});
-  };
+    setSearchTerm('')
+    setMinScoreFilter(30)
+    setRowErrors({})
+  }
 
   // Get the common symbol for a row (edited value or proposed value)
   const getCommonSymbol = (item, index) => {
-    return editedSymbols[index] !== undefined
-      ? editedSymbols[index]
-      : item.proposed_common_symbol;
-  };
+    return editedSymbols[index] !== undefined ? editedSymbols[index] : item.proposed_common_symbol
+  }
 
   const isPairCompletion = (item) => {
     return Boolean(
       item.target_already_mapped &&
-      item.target_common_symbol &&
-      item.proposed_common_symbol === item.target_common_symbol
-    );
-  };
+        item.target_common_symbol &&
+        item.proposed_common_symbol === item.target_common_symbol,
+    )
+  }
 
   const isConflict = (item) => {
-    return Boolean(item.target_already_mapped && !isPairCompletion(item));
-  };
+    return Boolean(item.target_already_mapped && !isPairCompletion(item))
+  }
 
   // Handle common symbol editing
   const handleSymbolChange = (index, value) => {
-    setEditedSymbols(prev => ({ ...prev, [index]: value }));
+    setEditedSymbols((prev) => ({ ...prev, [index]: value }))
     // Clear any existing error for this row
     if (rowErrors[index] || createdRows[index]) {
-      setRowErrors(prev => {
-        const newErrors = { ...prev };
-        delete newErrors[index];
-        return newErrors;
-      });
+      setRowErrors((prev) => {
+        const newErrors = { ...prev }
+        delete newErrors[index]
+        return newErrors
+      })
       // Reset created flag on edit to avoid stale badge
-      setCreatedRows(prev => {
-        const newCreated = { ...prev };
-        delete newCreated[index];
-        return newCreated;
-      });
+      setCreatedRows((prev) => {
+        const newCreated = { ...prev }
+        delete newCreated[index]
+        return newCreated
+      })
     }
-  };
+  }
 
   // Handle creating mappings for a suggestion row
   const handleCreateMapping = async (item, index) => {
-    const commonSymbol = getCommonSymbol(item, index);
+    const commonSymbol = getCommonSymbol(item, index)
     if (!commonSymbol?.trim()) {
-      return;
+      return
     }
 
     if (isConflict(item)) {
-      const context = `${item.target_class}/${item.target_symbol}`;
-      const message = `Target already mapped to a different symbol (${item.target_common_symbol || 'unknown'}).`;
+      const context = `${item.target_class}/${item.target_symbol}`
+      const message = `Target already mapped to a different symbol (${item.target_common_symbol || 'unknown'}).`
       if (pushToast) {
         pushToast({
-          title: "Cannot create mapping",
+          title: 'Cannot create mapping',
           body: `${context}: ${message}`,
-          color: "warning",
-        });
+          color: 'warning',
+        })
       }
-      return;
+      return
     }
 
-    const pairCompletion = isPairCompletion(item);
+    const pairCompletion = isPairCompletion(item)
 
-    setCreatingRows(prev => ({ ...prev, [index]: true }));
+    setCreatingRows((prev) => ({ ...prev, [index]: true }))
 
     try {
       const payload = [
@@ -284,7 +286,7 @@ const SuggestMappingsModal = ({ visible, onClose, onSuccess, pushToast }) => {
           class_symbol: item.source_symbol,
           is_active: true,
         },
-      ];
+      ]
 
       // Only add target mapping when it isn't already mapped to the same common_symbol
       if (!pairCompletion) {
@@ -294,38 +296,38 @@ const SuggestMappingsModal = ({ visible, onClose, onSuccess, pushToast }) => {
           class_type: item.target_type,
           class_symbol: item.target_symbol,
           is_active: true,
-        });
+        })
       }
 
-      await createAssetMapping(payload);
+      await createAssetMapping(payload)
 
       // Mark as created only when both succeed
-      setCreatedRows(prev => ({ ...prev, [index]: true }));
+      setCreatedRows((prev) => ({ ...prev, [index]: true }))
 
       // Call onSuccess to refresh parent data if provided
       if (onSuccess) {
-        onSuccess();
+        onSuccess()
       }
     } catch (error) {
-      console.error("Error creating mapping:", error);
-      const context = `${item.source_class}/${item.source_symbol} → ${item.target_class}/${item.target_symbol}`;
+      console.error('Error creating mapping:', error)
+      const context = `${item.source_class}/${item.source_symbol} → ${item.target_class}/${item.target_symbol}`
       if (pushToast) {
         pushToast({
-          title: "Create mappings failed",
-          body: `${context}: ${error.message || "Failed to create mappings."}`,
-          color: "danger",
-        });
+          title: 'Create mappings failed',
+          body: `${context}: ${error.message || 'Failed to create mappings.'}`,
+          color: 'danger',
+        })
       }
     } finally {
-      setCreatingRows(prev => ({ ...prev, [index]: false }));
+      setCreatingRows((prev) => ({ ...prev, [index]: false }))
     }
-  };
+  }
 
   return (
-    <CModal 
-      visible={visible} 
-      onClose={onClose} 
-      backdrop="static" 
+    <CModal
+      visible={visible}
+      onClose={onClose}
+      backdrop="static"
       fullscreen="lg"
       size="xl"
       className="suggest-mappings-modal"
@@ -354,13 +356,11 @@ const SuggestMappingsModal = ({ visible, onClose, onSuccess, pushToast }) => {
             <CRow className="mb-4 align-items-end">
               <CCol md={5}>
                 <CFormLabel htmlFor="source_class">Source Provider/Broker</CFormLabel>
-                <CFormSelect
-                  id="source_class"
-                  value={sourceClass}
-                  onChange={handleSourceChange}
-                >
-                  <option value="" disabled>Select source...</option>
-                  {classData.map(cls => (
+                <CFormSelect id="source_class" value={sourceClass} onChange={handleSourceChange}>
+                  <option value="" disabled>
+                    Select source...
+                  </option>
+                  {classData.map((cls) => (
                     <option key={cls.class_name} value={cls.class_name}>
                       {cls.class_name} ({cls.class_type})
                     </option>
@@ -380,10 +380,12 @@ const SuggestMappingsModal = ({ visible, onClose, onSuccess, pushToast }) => {
                   onChange={handleTargetChange}
                   disabled={!sourceClass}
                 >
-                  <option value="" disabled>Select target...</option>
+                  <option value="" disabled>
+                    Select target...
+                  </option>
                   {classData
-                    .filter(cls => cls.class_name !== sourceClass)
-                    .map(cls => (
+                    .filter((cls) => cls.class_name !== sourceClass)
+                    .map((cls) => (
                       <option key={cls.class_name} value={cls.class_name}>
                         {cls.class_name} ({cls.class_type})
                       </option>
@@ -448,27 +450,45 @@ const SuggestMappingsModal = ({ visible, onClose, onSuccess, pushToast }) => {
                         <CTable striped hover responsive>
                           <CTableHead>
                             <CTableRow>
-                              <CTableHeaderCell style={{ width: '12%' }}>Source Symbol</CTableHeaderCell>
-                              <CTableHeaderCell style={{ width: '15%' }}>Source Name</CTableHeaderCell>
-                              <CTableHeaderCell style={{ width: '12%' }}>Target Symbol</CTableHeaderCell>
-                              <CTableHeaderCell style={{ width: '15%' }}>Target Name</CTableHeaderCell>
-                              <CTableHeaderCell style={{ width: '8%' }} className="text-center">ID Match</CTableHeaderCell>
-                              <CTableHeaderCell style={{ width: '8%' }} className="text-center">Score</CTableHeaderCell>
-                              <CTableHeaderCell style={{ width: '18%' }}>Common Symbol</CTableHeaderCell>
-                              <CTableHeaderCell style={{ width: '12%' }} className="text-center">Actions</CTableHeaderCell>
+                              <CTableHeaderCell style={{ width: '12%' }}>
+                                Source Symbol
+                              </CTableHeaderCell>
+                              <CTableHeaderCell style={{ width: '15%' }}>
+                                Source Name
+                              </CTableHeaderCell>
+                              <CTableHeaderCell style={{ width: '12%' }}>
+                                Target Symbol
+                              </CTableHeaderCell>
+                              <CTableHeaderCell style={{ width: '15%' }}>
+                                Target Name
+                              </CTableHeaderCell>
+                              <CTableHeaderCell style={{ width: '8%' }} className="text-center">
+                                ID Match
+                              </CTableHeaderCell>
+                              <CTableHeaderCell style={{ width: '8%' }} className="text-center">
+                                Score
+                              </CTableHeaderCell>
+                              <CTableHeaderCell style={{ width: '18%' }}>
+                                Common Symbol
+                              </CTableHeaderCell>
+                              <CTableHeaderCell style={{ width: '12%' }} className="text-center">
+                                Actions
+                              </CTableHeaderCell>
                             </CTableRow>
                           </CTableHead>
                           <CTableBody>
                             {suggestions.map((item, index) => {
-                              const idMatchStyle = getIdMatchBadgeStyle(item.id_match);
-                              const scoreStyle = getScoreBadgeStyle(item.score);
-                              const isCreating = creatingRows[index];
-                              const isCreated = createdRows[index];
-                              const commonSymbol = getCommonSymbol(item, index);
-                              const pairCompletion = isPairCompletion(item);
-                              const conflict = isConflict(item);
+                              const idMatchStyle = getIdMatchBadgeStyle(item.id_match)
+                              const scoreStyle = getScoreBadgeStyle(item.score)
+                              const isCreating = creatingRows[index]
+                              const isCreated = createdRows[index]
+                              const commonSymbol = getCommonSymbol(item, index)
+                              const pairCompletion = isPairCompletion(item)
+                              const conflict = isConflict(item)
                               return (
-                                <CTableRow key={`${item.source_symbol}-${item.target_symbol}-${index}`}>
+                                <CTableRow
+                                  key={`${item.source_symbol}-${item.target_symbol}-${index}`}
+                                >
                                   <CTableDataCell>{item.source_symbol}</CTableDataCell>
                                   <CTableDataCell>{item.source_name || '-'}</CTableDataCell>
                                   <CTableDataCell>
@@ -492,12 +512,18 @@ const SuggestMappingsModal = ({ visible, onClose, onSuccess, pushToast }) => {
                                   </CTableDataCell>
                                   <CTableDataCell>{item.target_name || '-'}</CTableDataCell>
                                   <CTableDataCell className="text-center">
-                                    <CBadge color={idMatchStyle.color} textColor={idMatchStyle.textColor}>
+                                    <CBadge
+                                      color={idMatchStyle.color}
+                                      textColor={idMatchStyle.textColor}
+                                    >
                                       {item.id_match ? 'Yes' : 'No'}
                                     </CBadge>
                                   </CTableDataCell>
                                   <CTableDataCell className="text-center">
-                                    <CBadge color={scoreStyle.color} textColor={scoreStyle.textColor}>
+                                    <CBadge
+                                      color={scoreStyle.color}
+                                      textColor={scoreStyle.textColor}
+                                    >
                                       {item.score.toFixed(1)}
                                     </CBadge>
                                   </CTableDataCell>
@@ -512,7 +538,9 @@ const SuggestMappingsModal = ({ visible, onClose, onSuccess, pushToast }) => {
                                   </CTableDataCell>
                                   <CTableDataCell className="text-center">
                                     {isCreated ? (
-                                      <CBadge color="success" textColor="white">Created</CBadge>
+                                      <CBadge color="success" textColor="white">
+                                        Created
+                                      </CBadge>
                                     ) : (
                                       <CButton
                                         size="sm"
@@ -520,16 +548,12 @@ const SuggestMappingsModal = ({ visible, onClose, onSuccess, pushToast }) => {
                                         onClick={() => handleCreateMapping(item, index)}
                                         disabled={isCreating || !commonSymbol?.trim()}
                                       >
-                                        {isCreating ? (
-                                          <CSpinner size="sm" />
-                                        ) : (
-                                          'Create'
-                                        )}
+                                        {isCreating ? <CSpinner size="sm" /> : 'Create'}
                                       </CButton>
                                     )}
                                   </CTableDataCell>
                                 </CTableRow>
-                              );
+                              )
                             })}
                           </CTableBody>
                         </CTable>
@@ -575,7 +599,7 @@ const SuggestMappingsModal = ({ visible, onClose, onSuccess, pushToast }) => {
         </CButton>
       </CModalFooter>
     </CModal>
-  );
-};
+  )
+}
 
-export default SuggestMappingsModal;
+export default SuggestMappingsModal

--- a/web/src/views/registry/ClassSummaryCard.js
+++ b/web/src/views/registry/ClassSummaryCard.js
@@ -1,18 +1,18 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types' // For prop type validation
-import { 
+import {
   CCard,
-  CCardBody, 
-  CCardHeader, 
-  CCardTitle, 
-  CSpinner, 
+  CCardBody,
+  CCardHeader,
+  CCardTitle,
+  CSpinner,
   CButton,
   CModal,
   CModalHeader,
   CModalTitle,
   CModalBody,
   CModalFooter,
- } from '@coreui/react-pro'
+} from '@coreui/react-pro'
 import CIcon from '@coreui/icons-react'
 // Import icons you'll use in this card
 import {
@@ -24,7 +24,8 @@ import {
   cilTrash,
   cilSync,
   cilCheckCircle,
-  cilSettings } from '@coreui/icons'
+  cilSettings,
+} from '@coreui/icons'
 import { updateAssetsForClass, deleteRegisteredClass } from '../services/registry_api'
 import ProviderConfigModal from './ProviderConfigModal'
 
@@ -35,62 +36,63 @@ const getIconForType = (classType) => {
   return cilCode // Default icon
 }
 const getTypeTextForType = (classType) => {
-    if (classType === 'provider') return 'Data Provider'
-    if (classType === 'broker') return 'Broker'
-    return 'Unknown Type' // Default text
+  if (classType === 'provider') return 'Data Provider'
+  if (classType === 'broker') return 'Broker'
+  return 'Unknown Type' // Default text
 }
 
 const ClassSummaryCard = ({ class_summary, displayToast, onAssetsRefreshed }) => {
-    // State to Manage Card Refreshing
-    const [isRefreshing, setIsRefreshing] = useState(false)
-    const [isDeleting, setIsDeleting] = useState(false)
-    const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false)
-    const [isConfigModalVisible, setIsConfigModalVisible] = useState(false)
+  // State to Manage Card Refreshing
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false)
+  const [isConfigModalVisible, setIsConfigModalVisible] = useState(false)
 
-    const handleRefresh = async () => {
-        setIsRefreshing(true)
-        // console.log(`Refreshing assets for: ${class_summary.class_name}`) // Keep for debugging if needed
-        try {
-            const stats = await updateAssetsForClass(class_summary.class_type, class_summary.class_name)
-            // console.log(`Assets refreshed successfully for: ${class_summary.class_name}`, stats) // Keep for debugging
+  const handleRefresh = async () => {
+    setIsRefreshing(true)
+    // console.log(`Refreshing assets for: ${class_summary.class_name}`) // Keep for debugging if needed
+    try {
+      const stats = await updateAssetsForClass(class_summary.class_type, class_summary.class_name)
+      // console.log(`Assets refreshed successfully for: ${class_summary.class_name}`, stats) // Keep for debugging
 
-            let toastMessage = `Assets for ${class_summary.class_name} refreshed.`;
-            if (stats) {
-                toastMessage += ` Added: ${stats.added_symbols || 0}, Updated: ${stats.updated_symbols || 0}, Failed: ${stats.failed_symbols || 0}.`;
-            }
+      let toastMessage = `Assets for ${class_summary.class_name} refreshed.`
+      if (stats) {
+        toastMessage += ` Added: ${stats.added_symbols || 0}, Updated: ${stats.updated_symbols || 0}, Failed: ${stats.failed_symbols || 0}.`
+      }
 
-            if (displayToast) {
-                displayToast({
-                    title: 'Assets Refreshed',
-                    body: toastMessage,
-                    color: 'success',
-                    icon: cilCheckCircle,
-                });
-            }
-            if (onAssetsRefreshed) {
-                onAssetsRefreshed(); // This will trigger fetchClasses in Registry.js
-            }
-        } catch (error) {
-            console.error(`Error refreshing assets for ${class_summary.class_name}:`, error)
-            if (displayToast) {
-                displayToast({
-                    title: 'Refresh Failed',
-                    body: error.message || `Failed to refresh assets for ${class_summary.class_name}.`,
-                    color: 'danger',
-                    icon: cilWarning,
-                });
-            }
-        } finally {
-            setIsRefreshing(false)
-        }
+      if (displayToast) {
+        displayToast({
+          title: 'Assets Refreshed',
+          body: toastMessage,
+          color: 'success',
+          icon: cilCheckCircle,
+        })
+      }
+      if (onAssetsRefreshed) {
+        onAssetsRefreshed() // This will trigger fetchClasses in Registry.js
+      }
+    } catch (error) {
+      console.error(`Error refreshing assets for ${class_summary.class_name}:`, error)
+      if (displayToast) {
+        displayToast({
+          title: 'Refresh Failed',
+          body: error.message || `Failed to refresh assets for ${class_summary.class_name}.`,
+          color: 'danger',
+          icon: cilWarning,
+        })
+      }
+    } finally {
+      setIsRefreshing(false)
     }
+  }
 
   const openDeleteModal = () => {
     setIsDeleteModalVisible(true)
   }
 
   const closeDeleteModal = () => {
-    if (!isDeleting) { // Prevent closing if delete is in progress, or allow it
+    if (!isDeleting) {
+      // Prevent closing if delete is in progress, or allow it
       setIsDeleteModalVisible(false)
     }
   }
@@ -130,7 +132,9 @@ const ClassSummaryCard = ({ class_summary, displayToast, onAssetsRefreshed }) =>
 
   return (
     <>
-      <CCard className="mb-4 h-100"> {/* h-100 for equal height cards in a row */}
+      <CCard className="mb-4 h-100">
+        {' '}
+        {/* h-100 for equal height cards in a row */}
         <CCardHeader className="d-flex justify-content-between align-items-center">
           {/* Card Title - Left Justified */}
           <CCardTitle as="h6" className="mb-0 text-truncate" title={class_summary.class_name}>
@@ -139,54 +143,60 @@ const ClassSummaryCard = ({ class_summary, displayToast, onAssetsRefreshed }) =>
 
           {/* Card Icon - Right Justified */}
           <div className="d-flex align-items-center">
-              {class_summary.class_subtype !== 'UserIndex' && (
-                <CButton
-                    variant="ghost"
-                    color="body"
-                    size="sm"
-                    onClick={handleRefresh}
-                    disabled={isRefreshing}
-                    className="p-1 me-2"
-                    title="Refresh Assets"
-                >
-                    {isRefreshing ? (
-                        <CSpinner size="sm" component="span" aria-hidden="true" color="success" title="Refreshing..."/>
-                    ) : (
-                        <CIcon icon={cilSync} className="sm" />
-                    )}
-                </CButton>
-              )}
+            {class_summary.class_subtype !== 'UserIndex' && (
               <CButton
                 variant="ghost"
                 color="body"
                 size="sm"
-                onClick={() => setIsConfigModalVisible(true)}
-                disabled={isRefreshing || isDeleting}
+                onClick={handleRefresh}
+                disabled={isRefreshing}
                 className="p-1 me-2"
-                title="Provider Settings"
+                title="Refresh Assets"
               >
-                <CIcon icon={cilSettings} className="sm" />
+                {isRefreshing ? (
+                  <CSpinner
+                    size="sm"
+                    component="span"
+                    aria-hidden="true"
+                    color="success"
+                    title="Refreshing..."
+                  />
+                ) : (
+                  <CIcon icon={cilSync} className="sm" />
+                )}
               </CButton>
-              <CButton
-                variant="ghost"
-                color="danger" // Make it red
-                size="sm"
-                onClick={openDeleteModal}
-                disabled={isRefreshing || isDeleting} // Disable if refreshing or deleting
-                className="p-1 me-2"
-                title="Delete Class"
-              >
-                <CIcon icon={cilTrash} className="sm" />
-              </CButton>
-              <div
+            )}
+            <CButton
+              variant="ghost"
+              color="body"
+              size="sm"
+              onClick={() => setIsConfigModalVisible(true)}
+              disabled={isRefreshing || isDeleting}
+              className="p-1 me-2"
+              title="Provider Settings"
+            >
+              <CIcon icon={cilSettings} className="sm" />
+            </CButton>
+            <CButton
+              variant="ghost"
+              color="danger" // Make it red
+              size="sm"
+              onClick={openDeleteModal}
+              disabled={isRefreshing || isDeleting} // Disable if refreshing or deleting
+              className="p-1 me-2"
+              title="Delete Class"
+            >
+              <CIcon icon={cilTrash} className="sm" />
+            </CButton>
+            <div
               className={`bg-${
-                  class_summary.class_type === 'provider' ? 'info' : 'warning'
+                class_summary.class_type === 'provider' ? 'info' : 'warning'
               } bg-opacity-25 text-${
-                  class_summary.class_type === 'provider' ? 'info' : 'warning'
+                class_summary.class_type === 'provider' ? 'info' : 'warning'
               } rounded p-2 ms-2`}
-              >
+            >
               <CIcon icon={getIconForType(class_summary.class_type)} size="lg" />
-              </div>
+            </div>
           </div>
         </CCardHeader>
         <CCardBody>
@@ -213,8 +223,9 @@ const ClassSummaryCard = ({ class_summary, displayToast, onAssetsRefreshed }) =>
           <CModalTitle>Confirm Deletion</CModalTitle>
         </CModalHeader>
         <CModalBody>
-          Are you sure you want to delete the class "{class_summary.class_name}" ({class_summary.class_type})?
-          This action cannot be undone and will also delete its associated file and asset data.
+          Are you sure you want to delete the class "{class_summary.class_name}" (
+          {class_summary.class_type})? This action cannot be undone and will also delete its
+          associated file and asset data.
         </CModalBody>
         <CModalFooter>
           <CButton color="secondary" onClick={closeDeleteModal} disabled={isDeleting}>

--- a/web/src/views/registry/CodeUploadModal.js
+++ b/web/src/views/registry/CodeUploadModal.js
@@ -43,9 +43,7 @@ const CodeUploadModal = ({ visible, onClose, onSubmit, isSubmitting }) => {
   }
 
   const handleSecretChange = (id, field, value) => {
-    setSecrets(
-      secrets.map((secret) => (secret.id === id ? { ...secret, [field]: value } : secret)),
-    )
+    setSecrets(secrets.map((secret) => (secret.id === id ? { ...secret, [field]: value } : secret)))
   }
 
   const handleSubmit = () => {
@@ -59,19 +57,22 @@ const CodeUploadModal = ({ visible, onClose, onSubmit, isSubmitting }) => {
     }
     for (const secret of secrets) {
       if (secret.keyValue && !secret.keyName) {
-        setError(`Secret with value "${secret.keyValue.substring(0,20)}..." is missing a key name.`)
+        setError(
+          `Secret with value "${secret.keyValue.substring(0, 20)}..." is missing a key name.`,
+        )
         return
       }
     }
     setError('')
-    
+
     // Transform the secrets array into the desired object format
     const secretsObject = secrets.reduce((acc, secret) => {
-      if (secret.keyName && secret.keyValue) { // Only include secrets that have both key and value
-        acc[secret.keyName] = secret.keyValue;
+      if (secret.keyName && secret.keyValue) {
+        // Only include secrets that have both key and value
+        acc[secret.keyName] = secret.keyValue
       }
-      return acc;
-    }, {});
+      return acc
+    }, {})
 
     onSubmit({ file: selectedFile, secrets: secretsObject, classType }) // Include classType
   }
@@ -105,13 +106,20 @@ const CodeUploadModal = ({ visible, onClose, onSubmit, isSubmitting }) => {
   }
 
   return (
-    <CModal size="lg" visible={visible} onClose={isSubmitting ? () => {} : handleCloseModal} backdrop="static">
+    <CModal
+      size="lg"
+      visible={visible}
+      onClose={isSubmitting ? () => {} : handleCloseModal}
+      backdrop="static"
+    >
       <CModalHeader>
         <CModalTitle>Upload Provider or Broker Class</CModalTitle>
       </CModalHeader>
       <CModalBody>
         {error && <CAlert color="danger">{error}</CAlert>}
-        <CRow className="mb-3"> {/* Add a row for Class Type selection */}
+        <CRow className="mb-3">
+          {' '}
+          {/* Add a row for Class Type selection */}
           <CCol>
             <CFormLabel htmlFor="classTypeSelect">Class Type</CFormLabel>
             <CFormSelect
@@ -134,7 +142,12 @@ const CodeUploadModal = ({ visible, onClose, onSubmit, isSubmitting }) => {
             <h6>Python File</h6>
             <div
               className="border p-3 text-center"
-              style={{ minHeight: '160px', cursor: 'pointer', borderStyle: 'dashed', borderWidth: '2px' }} // Adjusted minHeight
+              style={{
+                minHeight: '160px',
+                cursor: 'pointer',
+                borderStyle: 'dashed',
+                borderWidth: '2px',
+              }} // Adjusted minHeight
               onClick={() => !isSubmitting && document.getElementById('fileInput')?.click()}
               onDragOver={handleDragOver}
               onDragLeave={handleDragLeave}
@@ -153,7 +166,11 @@ const CodeUploadModal = ({ visible, onClose, onSubmit, isSubmitting }) => {
                   <CIcon icon={cilFile} size="3xl" className="mb-2 text-success" />
                   <p>{fileName}</p>
                   {!isSubmitting && (
-                    <CButton size="sm" color="link" onClick={() => document.getElementById('fileInput')?.click()}>
+                    <CButton
+                      size="sm"
+                      color="link"
+                      onClick={() => document.getElementById('fileInput')?.click()}
+                    >
                       Change file
                     </CButton>
                   )}
@@ -166,9 +183,7 @@ const CodeUploadModal = ({ visible, onClose, onSubmit, isSubmitting }) => {
                 </>
               )}
             </div>
-            <small className="form-text text-body-secondary mt-1">
-              Upload a Python file (.py)
-            </small>
+            <small className="form-text text-body-secondary mt-1">Upload a Python file (.py)</small>
           </CCol>
 
           {/* Right Side: Secrets Configuration */}
@@ -212,7 +227,13 @@ const CodeUploadModal = ({ visible, onClose, onSubmit, isSubmitting }) => {
               </CRow>
             ))}
             {!isSubmitting && (
-              <CButton color="secondary" variant="outline" size="sm" onClick={handleAddSecret} className="mt-2">
+              <CButton
+                color="secondary"
+                variant="outline"
+                size="sm"
+                onClick={handleAddSecret}
+                className="mt-2"
+              >
                 <CIcon icon={cilPlus} className="me-1" /> Add Secret
               </CButton>
             )}

--- a/web/src/views/registry/ProviderConfigModal.js
+++ b/web/src/views/registry/ProviderConfigModal.js
@@ -89,6 +89,8 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
 
   // Track original quote preference to detect changes for re-map prompt
   const [originalQuotePreference, setOriginalQuotePreference] = useState(null)
+  // Control visibility of re-map prompt modal
+  const [showRemapPrompt, setShowRemapPrompt] = useState(false)
 
   // Ref to track which provider's secret keys have been loaded
   const secretKeysLoadedRef = useRef(null)
@@ -227,8 +229,14 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
         })
       }
 
-      // Close modal on success
-      handleClose()
+      // Check if quote preference changed - if so, prompt for re-map
+      if (hasQuotePreferenceChanged()) {
+        setShowRemapPrompt(true)
+        // Don't close yet - wait for user to respond to re-map prompt
+      } else {
+        // Close modal on success
+        handleClose()
+      }
     } catch (err) {
       console.error('Failed to update provider configuration:', err)
       setError(`Failed to save configuration: ${err.message}`)
@@ -245,6 +253,7 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
     setSecretValues({})
     setShowConfirmDialog(false)
     setOriginalQuotePreference(null)
+    setShowRemapPrompt(false)
     secretKeysLoadedRef.current = null
     onClose()
   }
@@ -341,6 +350,15 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
   const hasChanges = () => {
     // Simple change detection - in a real app you'd do deep comparison
     return true // For now, always allow saving
+  }
+
+  // Check if quote preference changed in a meaningful way (for re-map prompt)
+  const hasQuotePreferenceChanged = () => {
+    const currentPref = config.crypto?.preferred_quote_currency || null
+    // Both null/empty means no change
+    if (!originalQuotePreference && !currentPref) return false
+    // One is set, other is not, or different values
+    return originalQuotePreference !== currentPref
   }
 
   return (

--- a/web/src/views/registry/ProviderConfigModal.js
+++ b/web/src/views/registry/ProviderConfigModal.js
@@ -28,6 +28,7 @@ import {
 import CIcon from '@coreui/icons-react'
 import { cilSettings, cilLockLocked, cilChartLine, cilClock, cilStorage } from '@coreui/icons'
 import { getProviderConfig, updateProviderConfig, getAvailableQuoteCurrencies, getSecretKeys, updateSecrets } from '../services/registry_api'
+import RemapPromptModal from './RemapPromptModal'
 
 // Default values for live provider scheduling
 const DEFAULT_PRE_CLOSE_SECONDS = 30
@@ -91,6 +92,8 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
   const [originalQuotePreference, setOriginalQuotePreference] = useState(null)
   // Control visibility of re-map prompt modal
   const [showRemapPrompt, setShowRemapPrompt] = useState(false)
+  // Track if re-map is in progress
+  const [isRemapping, setIsRemapping] = useState(false)
 
   // Ref to track which provider's secret keys have been loaded
   const secretKeysLoadedRef = useRef(null)
@@ -254,6 +257,7 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
     setShowConfirmDialog(false)
     setOriginalQuotePreference(null)
     setShowRemapPrompt(false)
+    setIsRemapping(false)
     secretKeysLoadedRef.current = null
     onClose()
   }
@@ -359,6 +363,28 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
     if (!originalQuotePreference && !currentPref) return false
     // One is set, other is not, or different values
     return originalQuotePreference !== currentPref
+  }
+
+  // Handler when user confirms re-map from the prompt modal
+  const handleRemapConfirm = async () => {
+    setIsRemapping(true)
+    // T023 will wire this to actually call remapAssetMappings()
+    // For now, just close and reset
+    setIsRemapping(false)
+    setShowRemapPrompt(false)
+    handleClose()
+  }
+
+  // Handler when user declines re-map from the prompt modal
+  const handleRemapDecline = () => {
+    setShowRemapPrompt(false)
+    handleClose()
+  }
+
+  // Handler to close the re-map prompt modal
+  const handleRemapPromptClose = () => {
+    setShowRemapPrompt(false)
+    handleClose()
   }
 
   return (
@@ -973,6 +999,16 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
           </CButton>
         </CModalFooter>
       </CModal>
+
+      {/* Re-map prompt modal for quote preference changes */}
+      <RemapPromptModal
+        visible={showRemapPrompt}
+        onClose={handleRemapPromptClose}
+        onConfirm={handleRemapConfirm}
+        onDecline={handleRemapDecline}
+        isProcessing={isRemapping}
+        className={className}
+      />
     </CModal>
   )
 }

--- a/web/src/views/registry/ProviderConfigModal.js
+++ b/web/src/views/registry/ProviderConfigModal.js
@@ -402,7 +402,7 @@ const ProviderConfigModal = ({
       if (displayToast) {
         displayToast({
           title: 'Crypto Mappings Re-mapped',
-          body: `Successfully re-mapped crypto assets for ${className}. Deleted: ${result.deleted}, Created: ${result.created}, Skipped: ${result.skipped}.`,
+          body: `Successfully re-mapped crypto assets for ${className}. Deleted: ${result.deleted_mappings}, Created: ${result.created_mappings}, Skipped: ${result.skipped_mappings}.`,
           color: 'success',
           icon: cilChartLine,
         })

--- a/web/src/views/registry/ProviderConfigModal.js
+++ b/web/src/views/registry/ProviderConfigModal.js
@@ -27,7 +27,14 @@ import {
 } from '@coreui/react-pro'
 import CIcon from '@coreui/icons-react'
 import { cilSettings, cilLockLocked, cilChartLine, cilClock, cilStorage } from '@coreui/icons'
-import { getProviderConfig, updateProviderConfig, getAvailableQuoteCurrencies, getSecretKeys, updateSecrets, remapAssetMappings } from '../services/registry_api'
+import {
+  getProviderConfig,
+  updateProviderConfig,
+  getAvailableQuoteCurrencies,
+  getSecretKeys,
+  updateSecrets,
+  remapAssetMappings,
+} from '../services/registry_api'
 import RemapPromptModal from './RemapPromptModal'
 
 // Default values for live provider scheduling
@@ -57,9 +64,17 @@ const LOOKBACK_PRESETS = [
   { label: 'Max', value: 8000 },
 ]
 
-const ProviderConfigModal = ({ visible, onClose, classType, className, classSubtype, displayToast }) => {
+const ProviderConfigModal = ({
+  visible,
+  onClose,
+  classType,
+  className,
+  classSubtype,
+  displayToast,
+}) => {
   // Determine which tabs should be visible based on class_subtype
-  const showSchedulingTab = classSubtype === 'Historical' || classSubtype === 'Live' || classSubtype === 'IndexProvider'
+  const showSchedulingTab =
+    classSubtype === 'Historical' || classSubtype === 'Live' || classSubtype === 'IndexProvider'
   const showDataTab = classSubtype === 'Historical'
 
   const [activeTab, setActiveTab] = useState('trading')
@@ -69,11 +84,11 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
       delay_hours: 0,
       pre_close_seconds: DEFAULT_PRE_CLOSE_SECONDS,
       post_close_seconds: DEFAULT_POST_CLOSE_SECONDS,
-      sync_frequency: DEFAULT_SYNC_FREQUENCY
+      sync_frequency: DEFAULT_SYNC_FREQUENCY,
     },
     data: {
-      lookback_days: DEFAULT_LOOKBACK_DAYS
-    }
+      lookback_days: DEFAULT_LOOKBACK_DAYS,
+    },
   })
   const [availableCurrencies, setAvailableCurrencies] = useState([])
   const [loading, setLoading] = useState(false)
@@ -115,7 +130,13 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
   // Load secret keys when API tab is activated
   useEffect(() => {
     const providerKey = `${classType}:${className}`
-    if (visible && activeTab === 'api' && classType && className && secretKeysLoadedRef.current !== providerKey) {
+    if (
+      visible &&
+      activeTab === 'api' &&
+      classType &&
+      className &&
+      secretKeysLoadedRef.current !== providerKey
+    ) {
       secretKeysLoadedRef.current = providerKey
       loadSecretKeys()
     }
@@ -134,11 +155,11 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
           delay_hours: prefs.scheduling?.delay_hours ?? 0,
           pre_close_seconds: prefs.scheduling?.pre_close_seconds ?? DEFAULT_PRE_CLOSE_SECONDS,
           post_close_seconds: prefs.scheduling?.post_close_seconds ?? DEFAULT_POST_CLOSE_SECONDS,
-          sync_frequency: prefs.scheduling?.sync_frequency ?? DEFAULT_SYNC_FREQUENCY
+          sync_frequency: prefs.scheduling?.sync_frequency ?? DEFAULT_SYNC_FREQUENCY,
         },
         data: {
-          lookback_days: prefs.data?.lookback_days ?? DEFAULT_LOOKBACK_DAYS
-        }
+          lookback_days: prefs.data?.lookback_days ?? DEFAULT_LOOKBACK_DAYS,
+        },
       })
       // Track original quote preference for re-map detection
       setOriginalQuotePreference(cryptoPrefs.preferred_quote_currency)
@@ -152,11 +173,11 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
           delay_hours: 0,
           pre_close_seconds: DEFAULT_PRE_CLOSE_SECONDS,
           post_close_seconds: DEFAULT_POST_CLOSE_SECONDS,
-          sync_frequency: DEFAULT_SYNC_FREQUENCY
+          sync_frequency: DEFAULT_SYNC_FREQUENCY,
         },
         data: {
-          lookback_days: DEFAULT_LOOKBACK_DAYS
-        }
+          lookback_days: DEFAULT_LOOKBACK_DAYS,
+        },
       })
     } finally {
       setLoading(false)
@@ -182,7 +203,7 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
       setSecretKeys(keys)
       // Initialize empty values for each key
       const initialValues = {}
-      keys.forEach(key => {
+      keys.forEach((key) => {
         initialValues[key] = ''
       })
       setSecretValues(initialValues)
@@ -207,19 +228,19 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
       // Add scheduling fields based on provider subtype
       if (classSubtype === 'Historical') {
         updateData.scheduling = {
-          delay_hours: config.scheduling.delay_hours
+          delay_hours: config.scheduling.delay_hours,
         }
         updateData.data = {
-          lookback_days: config.data.lookback_days
+          lookback_days: config.data.lookback_days,
         }
       } else if (classSubtype === 'Live') {
         updateData.scheduling = {
           pre_close_seconds: config.scheduling.pre_close_seconds,
-          post_close_seconds: config.scheduling.post_close_seconds
+          post_close_seconds: config.scheduling.post_close_seconds,
         }
       } else if (classSubtype === 'IndexProvider') {
         updateData.scheduling = {
-          sync_frequency: config.scheduling.sync_frequency
+          sync_frequency: config.scheduling.sync_frequency,
         }
       }
 
@@ -266,19 +287,19 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
   }
 
   const handleSecretChange = (key, value) => {
-    setSecretValues(prev => ({
+    setSecretValues((prev) => ({
       ...prev,
-      [key]: value
+      [key]: value,
     }))
   }
 
   const handleUpdateSecretsClick = () => {
     // Check if all fields are filled (after trimming whitespace)
     const trimmedValues = {}
-    secretKeys.forEach(key => {
+    secretKeys.forEach((key) => {
       trimmedValues[key] = secretValues[key]?.trim() || ''
     })
-    const emptyFields = secretKeys.filter(key => trimmedValues[key] === '')
+    const emptyFields = secretKeys.filter((key) => trimmedValues[key] === '')
     if (emptyFields.length > 0) {
       setSecretsError(`Please fill in all credential fields. Missing: ${emptyFields.join(', ')}`)
       return
@@ -305,7 +326,7 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
       }
       // Clear the values after successful update (for security)
       const clearedValues = {}
-      secretKeys.forEach(key => {
+      secretKeys.forEach((key) => {
         clearedValues[key] = ''
       })
       setSecretValues(clearedValues)
@@ -318,32 +339,32 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
   }
 
   const handlePreferenceChange = (field, value) => {
-    setConfig(prevConfig => ({
+    setConfig((prevConfig) => ({
       ...prevConfig,
       crypto: {
         ...prevConfig.crypto,
-        [field]: value || null
-      }
+        [field]: value || null,
+      },
     }))
   }
 
   const handleSchedulingChange = (field, value) => {
-    setConfig(prevConfig => ({
+    setConfig((prevConfig) => ({
       ...prevConfig,
       scheduling: {
         ...prevConfig.scheduling,
-        [field]: value
-      }
+        [field]: value,
+      },
     }))
   }
 
   const handleDataChange = (field, value) => {
-    setConfig(prevConfig => ({
+    setConfig((prevConfig) => ({
       ...prevConfig,
       data: {
         ...prevConfig.data,
-        [field]: value
-      }
+        [field]: value,
+      },
     }))
   }
 
@@ -376,7 +397,7 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
       const result = await remapAssetMappings({
         class_name: className,
         class_type: classType,
-        asset_class: 'crypto'
+        asset_class: 'crypto',
       })
       if (displayToast) {
         displayToast({
@@ -490,19 +511,23 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
                     <CFormSelect
                       id="preferredQuoteCurrency"
                       value={config.crypto?.preferred_quote_currency || ''}
-                      onChange={(e) => handlePreferenceChange('preferred_quote_currency', e.target.value)}
+                      onChange={(e) =>
+                        handlePreferenceChange('preferred_quote_currency', e.target.value)
+                      }
                       disabled={saving}
                     >
                       <option value="">No preference</option>
-                      {availableCurrencies.map(currency => (
+                      {availableCurrencies.map((currency) => (
                         <option key={currency} value={currency}>
                           {currency}
                         </option>
                       ))}
                     </CFormSelect>
                     <small className="form-text text-body-secondary">
-                      For crypto pairs, prefer this quote currency when available (e.g., USDC over USDT).
-                      {availableCurrencies.length === 0 && ' No crypto assets found for this provider.'}
+                      For crypto pairs, prefer this quote currency when available (e.g., USDC over
+                      USDT).
+                      {availableCurrencies.length === 0 &&
+                        ' No crypto assets found for this provider.'}
                     </small>
                   </CCol>
                 </CRow>
@@ -521,17 +546,15 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
                         <CCol>
                           <CAlert color="info">
                             <CIcon icon={cilClock} className="me-2" />
-                            Configure the delay offset for daily data collection.
-                            Historical providers pull data at midnight UTC by default.
+                            Configure the delay offset for daily data collection. Historical
+                            providers pull data at midnight UTC by default.
                           </CAlert>
                         </CCol>
                       </CRow>
 
                       <CRow className="mb-4">
                         <CCol md={8}>
-                          <CFormLabel htmlFor="delayHours">
-                            Delay Hours
-                          </CFormLabel>
+                          <CFormLabel htmlFor="delayHours">Delay Hours</CFormLabel>
                           <div className="d-flex align-items-center gap-3">
                             <CFormRange
                               id="delayHours"
@@ -539,11 +562,17 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
                               max={24}
                               step={1}
                               value={config.scheduling?.delay_hours || 0}
-                              onChange={(e) => handleSchedulingChange('delay_hours', parseInt(e.target.value, 10))}
+                              onChange={(e) =>
+                                handleSchedulingChange('delay_hours', parseInt(e.target.value, 10))
+                              }
                               disabled={saving}
                               className="flex-grow-1"
                             />
-                            <CBadge color="primary" className="px-3 py-2" style={{ minWidth: '50px' }}>
+                            <CBadge
+                              color="primary"
+                              className="px-3 py-2"
+                              style={{ minWidth: '50px' }}
+                            >
                               {config.scheduling?.delay_hours || 0}h
                             </CBadge>
                           </div>
@@ -555,7 +584,10 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
 
                       <CRow className="mb-3">
                         <CCol md={8}>
-                          <div className="p-3 border rounded" style={{ backgroundColor: 'var(--cui-body-secondary)' }}>
+                          <div
+                            className="p-3 border rounded"
+                            style={{ backgroundColor: 'var(--cui-body-secondary)' }}
+                          >
                             <strong>Pull Time Preview</strong>
                             <p className="mb-0 mt-2">
                               Daily data collection will run at{' '}
@@ -587,59 +619,82 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
 
                       <CRow className="mb-4">
                         <CCol md={8}>
-                          <CFormLabel htmlFor="preCloseSeconds">
-                            Pre-Close Seconds
-                          </CFormLabel>
+                          <CFormLabel htmlFor="preCloseSeconds">Pre-Close Seconds</CFormLabel>
                           <div className="d-flex align-items-center gap-3">
                             <CFormRange
                               id="preCloseSeconds"
                               min={0}
                               max={300}
                               step={5}
-                              value={config.scheduling?.pre_close_seconds ?? DEFAULT_PRE_CLOSE_SECONDS}
-                              onChange={(e) => handleSchedulingChange('pre_close_seconds', parseInt(e.target.value, 10))}
+                              value={
+                                config.scheduling?.pre_close_seconds ?? DEFAULT_PRE_CLOSE_SECONDS
+                              }
+                              onChange={(e) =>
+                                handleSchedulingChange(
+                                  'pre_close_seconds',
+                                  parseInt(e.target.value, 10),
+                                )
+                              }
                               disabled={saving}
                               className="flex-grow-1"
                             />
-                            <CBadge color="primary" className="px-3 py-2" style={{ minWidth: '60px' }}>
+                            <CBadge
+                              color="primary"
+                              className="px-3 py-2"
+                              style={{ minWidth: '60px' }}
+                            >
                               {config.scheduling?.pre_close_seconds ?? DEFAULT_PRE_CLOSE_SECONDS}s
                             </CBadge>
                           </div>
                           <small className="form-text text-body-secondary">
-                            Start listening this many seconds before bar close. Range: 0-300 seconds.
+                            Start listening this many seconds before bar close. Range: 0-300
+                            seconds.
                           </small>
                         </CCol>
                       </CRow>
 
                       <CRow className="mb-4">
                         <CCol md={8}>
-                          <CFormLabel htmlFor="postCloseSeconds">
-                            Post-Close Seconds
-                          </CFormLabel>
+                          <CFormLabel htmlFor="postCloseSeconds">Post-Close Seconds</CFormLabel>
                           <div className="d-flex align-items-center gap-3">
                             <CFormRange
                               id="postCloseSeconds"
                               min={0}
                               max={60}
                               step={1}
-                              value={config.scheduling?.post_close_seconds ?? DEFAULT_POST_CLOSE_SECONDS}
-                              onChange={(e) => handleSchedulingChange('post_close_seconds', parseInt(e.target.value, 10))}
+                              value={
+                                config.scheduling?.post_close_seconds ?? DEFAULT_POST_CLOSE_SECONDS
+                              }
+                              onChange={(e) =>
+                                handleSchedulingChange(
+                                  'post_close_seconds',
+                                  parseInt(e.target.value, 10),
+                                )
+                              }
                               disabled={saving}
                               className="flex-grow-1"
                             />
-                            <CBadge color="primary" className="px-3 py-2" style={{ minWidth: '60px' }}>
+                            <CBadge
+                              color="primary"
+                              className="px-3 py-2"
+                              style={{ minWidth: '60px' }}
+                            >
                               {config.scheduling?.post_close_seconds ?? DEFAULT_POST_CLOSE_SECONDS}s
                             </CBadge>
                           </div>
                           <small className="form-text text-body-secondary">
-                            Continue listening this many seconds after bar close to capture late data. Range: 0-60 seconds.
+                            Continue listening this many seconds after bar close to capture late
+                            data. Range: 0-60 seconds.
                           </small>
                         </CCol>
                       </CRow>
 
                       <CRow className="mb-3">
                         <CCol md={10}>
-                          <div className="p-3 border rounded" style={{ backgroundColor: 'var(--cui-body-secondary)' }}>
+                          <div
+                            className="p-3 border rounded"
+                            style={{ backgroundColor: 'var(--cui-body-secondary)' }}
+                          >
                             <strong>Listening Window Preview</strong>
                             <div className="mt-3 position-relative" style={{ height: '60px' }}>
                               {/* Timeline visualization */}
@@ -650,7 +705,7 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
                                   right: '0%',
                                   top: '25px',
                                   height: '4px',
-                                  borderRadius: '2px'
+                                  borderRadius: '2px',
                                 }}
                               />
 
@@ -663,7 +718,7 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
                                   top: '20px',
                                   height: '14px',
                                   borderRadius: '4px 0 0 4px',
-                                  opacity: 0.8
+                                  opacity: 0.8,
                                 }}
                               />
 
@@ -676,7 +731,7 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
                                   width: '3px',
                                   height: '24px',
                                   marginLeft: '-1.5px',
-                                  borderRadius: '2px'
+                                  borderRadius: '2px',
                                 }}
                               />
 
@@ -689,39 +744,82 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
                                   top: '20px',
                                   height: '14px',
                                   borderRadius: '0 4px 4px 0',
-                                  opacity: 0.8
+                                  opacity: 0.8,
                                 }}
                               />
 
                               {/* Labels */}
-                              <div className="position-absolute text-muted small" style={{ left: '0%', top: '45px' }}>
-                                -{config.scheduling?.pre_close_seconds ?? DEFAULT_PRE_CLOSE_SECONDS}s
+                              <div
+                                className="position-absolute text-muted small"
+                                style={{ left: '0%', top: '45px' }}
+                              >
+                                -{config.scheduling?.pre_close_seconds ?? DEFAULT_PRE_CLOSE_SECONDS}
+                                s
                               </div>
-                              <div className="position-absolute text-danger small fw-bold" style={{ left: '50%', top: '0px', transform: 'translateX(-50%)' }}>
+                              <div
+                                className="position-absolute text-danger small fw-bold"
+                                style={{ left: '50%', top: '0px', transform: 'translateX(-50%)' }}
+                              >
                                 Bar Close
                               </div>
-                              <div className="position-absolute text-muted small" style={{ right: '0%', top: '45px' }}>
-                                +{config.scheduling?.post_close_seconds ?? DEFAULT_POST_CLOSE_SECONDS}s
+                              <div
+                                className="position-absolute text-muted small"
+                                style={{ right: '0%', top: '45px' }}
+                              >
+                                +
+                                {config.scheduling?.post_close_seconds ??
+                                  DEFAULT_POST_CLOSE_SECONDS}
+                                s
                               </div>
                             </div>
                             <div className="mt-4 d-flex justify-content-between small text-body-secondary">
                               <span>
-                                <span className="d-inline-block me-1" style={{ width: '12px', height: '12px', backgroundColor: 'var(--cui-info)', borderRadius: '2px', opacity: 0.8 }}></span>
+                                <span
+                                  className="d-inline-block me-1"
+                                  style={{
+                                    width: '12px',
+                                    height: '12px',
+                                    backgroundColor: 'var(--cui-info)',
+                                    borderRadius: '2px',
+                                    opacity: 0.8,
+                                  }}
+                                ></span>
                                 Pre-close listening
                               </span>
                               <span>
-                                <span className="d-inline-block me-1" style={{ width: '12px', height: '12px', backgroundColor: 'var(--cui-danger)', borderRadius: '2px' }}></span>
+                                <span
+                                  className="d-inline-block me-1"
+                                  style={{
+                                    width: '12px',
+                                    height: '12px',
+                                    backgroundColor: 'var(--cui-danger)',
+                                    borderRadius: '2px',
+                                  }}
+                                ></span>
                                 Bar close time
                               </span>
                               <span>
-                                <span className="d-inline-block me-1" style={{ width: '12px', height: '12px', backgroundColor: 'var(--cui-success)', borderRadius: '2px', opacity: 0.8 }}></span>
+                                <span
+                                  className="d-inline-block me-1"
+                                  style={{
+                                    width: '12px',
+                                    height: '12px',
+                                    backgroundColor: 'var(--cui-success)',
+                                    borderRadius: '2px',
+                                    opacity: 0.8,
+                                  }}
+                                ></span>
                                 Post-close listening
                               </span>
                             </div>
                             <p className="mb-0 mt-3 small">
                               Total listening window:{' '}
                               <CBadge color="success">
-                                {(config.scheduling?.pre_close_seconds ?? DEFAULT_PRE_CLOSE_SECONDS) + (config.scheduling?.post_close_seconds ?? DEFAULT_POST_CLOSE_SECONDS)} seconds
+                                {(config.scheduling?.pre_close_seconds ??
+                                  DEFAULT_PRE_CLOSE_SECONDS) +
+                                  (config.scheduling?.post_close_seconds ??
+                                    DEFAULT_POST_CLOSE_SECONDS)}{' '}
+                                seconds
                               </CBadge>
                             </p>
                           </div>
@@ -736,7 +834,8 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
                         <CCol>
                           <CAlert color="info">
                             <CIcon icon={cilClock} className="me-2" />
-                            Configure how often this IndexProvider automatically syncs its constituents.
+                            Configure how often this IndexProvider automatically syncs its
+                            constituents.
                           </CAlert>
                         </CCol>
                       </CRow>
@@ -745,7 +844,8 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
                         <CCol md={10}>
                           <CFormLabel className="fw-semibold">Sync Frequency</CFormLabel>
                           <p className="text-body-secondary small mb-3">
-                            How often should this IndexProvider automatically fetch and sync its constituents?
+                            How often should this IndexProvider automatically fetch and sync its
+                            constituents?
                           </p>
                           <div className="d-flex flex-column gap-2 mb-3">
                             {SYNC_FREQUENCY_OPTIONS.map((option) => (
@@ -762,8 +862,13 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
                                     </span>
                                   </span>
                                 }
-                                checked={(config.scheduling?.sync_frequency ?? DEFAULT_SYNC_FREQUENCY) === option.value}
-                                onChange={() => handleSchedulingChange('sync_frequency', option.value)}
+                                checked={
+                                  (config.scheduling?.sync_frequency ?? DEFAULT_SYNC_FREQUENCY) ===
+                                  option.value
+                                }
+                                onChange={() =>
+                                  handleSchedulingChange('sync_frequency', option.value)
+                                }
                                 disabled={saving}
                               />
                             ))}
@@ -773,16 +878,27 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
 
                       <CRow className="mb-3">
                         <CCol md={8}>
-                          <div className="p-3 border rounded" style={{ backgroundColor: 'var(--cui-body-secondary)' }}>
+                          <div
+                            className="p-3 border rounded"
+                            style={{ backgroundColor: 'var(--cui-body-secondary)' }}
+                          >
                             <strong>Sync Schedule Preview</strong>
                             <p className="mb-0 mt-2">
                               Constituents will be synced{' '}
                               <CBadge color="success" className="ms-1">
-                                {SYNC_FREQUENCY_OPTIONS.find(o => o.value === (config.scheduling?.sync_frequency ?? DEFAULT_SYNC_FREQUENCY))?.label || 'Weekly'}
+                                {SYNC_FREQUENCY_OPTIONS.find(
+                                  (o) =>
+                                    o.value ===
+                                    (config.scheduling?.sync_frequency ?? DEFAULT_SYNC_FREQUENCY),
+                                )?.label || 'Weekly'}
                               </CBadge>
                             </p>
                             <small className="text-body-secondary">
-                              {SYNC_FREQUENCY_OPTIONS.find(o => o.value === (config.scheduling?.sync_frequency ?? DEFAULT_SYNC_FREQUENCY))?.description || 'Sync at midnight UTC every Monday'}
+                              {SYNC_FREQUENCY_OPTIONS.find(
+                                (o) =>
+                                  o.value ===
+                                  (config.scheduling?.sync_frequency ?? DEFAULT_SYNC_FREQUENCY),
+                              )?.description || 'Sync at midnight UTC every Monday'}
                             </small>
                           </div>
                         </CCol>
@@ -813,7 +929,8 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
                     <CCol md={10}>
                       <CFormLabel className="fw-semibold">Lookback Period</CFormLabel>
                       <p className="text-body-secondary small mb-3">
-                        When subscribing to a new symbol, how much historical data should be fetched?
+                        When subscribing to a new symbol, how much historical data should be
+                        fetched?
                       </p>
                       <div className="d-flex flex-wrap gap-3 mb-3">
                         {LOOKBACK_PRESETS.map((preset) => (
@@ -823,7 +940,9 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
                             name="lookbackPreset"
                             id={`lookback-${preset.value}`}
                             label={preset.label}
-                            checked={(config.data?.lookback_days ?? DEFAULT_LOOKBACK_DAYS) === preset.value}
+                            checked={
+                              (config.data?.lookback_days ?? DEFAULT_LOOKBACK_DAYS) === preset.value
+                            }
                             onChange={() => handleDataChange('lookback_days', preset.value)}
                             disabled={saving}
                           />
@@ -833,11 +952,16 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
                           name="lookbackPreset"
                           id="lookback-custom"
                           label="Custom"
-                          checked={!LOOKBACK_PRESETS.some(p => p.value === (config.data?.lookback_days ?? DEFAULT_LOOKBACK_DAYS))}
+                          checked={
+                            !LOOKBACK_PRESETS.some(
+                              (p) =>
+                                p.value === (config.data?.lookback_days ?? DEFAULT_LOOKBACK_DAYS),
+                            )
+                          }
                           onChange={() => {
                             // When switching to custom, keep current value if valid, otherwise set to a reasonable default
                             const currentValue = config.data?.lookback_days ?? DEFAULT_LOOKBACK_DAYS
-                            if (!LOOKBACK_PRESETS.some(p => p.value === currentValue)) {
+                            if (!LOOKBACK_PRESETS.some((p) => p.value === currentValue)) {
                               // Already custom, keep value
                               return
                             }
@@ -847,7 +971,9 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
                           disabled={saving}
                         />
                       </div>
-                      {!LOOKBACK_PRESETS.some(p => p.value === (config.data?.lookback_days ?? DEFAULT_LOOKBACK_DAYS)) && (
+                      {!LOOKBACK_PRESETS.some(
+                        (p) => p.value === (config.data?.lookback_days ?? DEFAULT_LOOKBACK_DAYS),
+                      ) && (
                         <div className="mb-3">
                           <CFormLabel htmlFor="customLookbackDays" className="small">
                             Custom Lookback Days
@@ -889,14 +1015,21 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
                           </small>
                         </div>
                       )}
-                      <div className="p-3 border rounded" style={{ backgroundColor: 'var(--cui-body-secondary)' }}>
+                      <div
+                        className="p-3 border rounded"
+                        style={{ backgroundColor: 'var(--cui-body-secondary)' }}
+                      >
                         <p className="mb-0 text-body-secondary small">
                           Selected lookback:{' '}
                           <CBadge color="primary">
                             {config.data?.lookback_days ?? DEFAULT_LOOKBACK_DAYS} days
-                          </CBadge>
-                          {' '}
-                          ({LOOKBACK_PRESETS.find(p => p.value === (config.data?.lookback_days ?? DEFAULT_LOOKBACK_DAYS))?.label || 'Custom'})
+                          </CBadge>{' '}
+                          (
+                          {LOOKBACK_PRESETS.find(
+                            (p) =>
+                              p.value === (config.data?.lookback_days ?? DEFAULT_LOOKBACK_DAYS),
+                          )?.label || 'Custom'}
+                          )
                         </p>
                       </div>
                     </CCol>
@@ -907,7 +1040,8 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
               <CTabPane visible={activeTab === 'api'}>
                 <h6>API Secrets</h6>
                 <p className="text-body-secondary mb-3">
-                  Update API credentials for this provider. All credentials must be provided together.
+                  Update API credentials for this provider. All credentials must be provided
+                  together.
                 </p>
 
                 {secretsError && <CAlert color="danger">{secretsError}</CAlert>}
@@ -925,18 +1059,16 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
                 ) : (
                   <>
                     <CAlert color="warning" className="mb-4">
-                      <strong>Important:</strong> Updating credentials will replace all existing values.
-                      You must provide values for all fields. The provider will be automatically reloaded
-                      to use the new credentials.
+                      <strong>Important:</strong> Updating credentials will replace all existing
+                      values. You must provide values for all fields. The provider will be
+                      automatically reloaded to use the new credentials.
                     </CAlert>
 
                     <CRow className="mb-4">
                       <CCol md={8}>
                         {secretKeys.map((key) => (
                           <div key={key} className="mb-3">
-                            <CFormLabel htmlFor={`secret-${key}`}>
-                              {key}
-                            </CFormLabel>
+                            <CFormLabel htmlFor={`secret-${key}`}>{key}</CFormLabel>
                             <CFormInput
                               id={`secret-${key}`}
                               type="password"
@@ -956,7 +1088,7 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
                         <CButton
                           color="warning"
                           onClick={handleUpdateSecretsClick}
-                          disabled={savingSecrets || secretKeys.some(key => !secretValues[key])}
+                          disabled={savingSecrets || secretKeys.some((key) => !secretValues[key])}
                         >
                           {savingSecrets ? <CSpinner size="sm" className="me-1" /> : null}
                           {savingSecrets ? 'Updating Credentials...' : 'Update Credentials'}
@@ -975,11 +1107,7 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
         <CButton color="secondary" onClick={handleClose} disabled={saving}>
           Cancel
         </CButton>
-        <CButton
-          color="primary"
-          onClick={handleSave}
-          disabled={saving || loading}
-        >
+        <CButton color="primary" onClick={handleSave} disabled={saving || loading}>
           {saving ? <CSpinner size="sm" className="me-1" /> : null}
           {saving ? 'Saving...' : 'Save Changes'}
         </CButton>
@@ -1004,8 +1132,10 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
           </CAlert>
           <p className="mb-2">You are about to update the following credentials:</p>
           <ul className="mb-3">
-            {secretKeys.map(key => (
-              <li key={key}><code>{key}</code></li>
+            {secretKeys.map((key) => (
+              <li key={key}>
+                <code>{key}</code>
+              </li>
             ))}
           </ul>
           <p className="text-body-secondary small mb-0">

--- a/web/src/views/registry/ProviderConfigModal.js
+++ b/web/src/views/registry/ProviderConfigModal.js
@@ -94,6 +94,8 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
   const [showRemapPrompt, setShowRemapPrompt] = useState(false)
   // Track if re-map is in progress
   const [isRemapping, setIsRemapping] = useState(false)
+  // Track re-map error for retry functionality
+  const [remapError, setRemapError] = useState(null)
 
   // Ref to track which provider's secret keys have been loaded
   const secretKeysLoadedRef = useRef(null)
@@ -258,6 +260,7 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
     setOriginalQuotePreference(null)
     setShowRemapPrompt(false)
     setIsRemapping(false)
+    setRemapError(null)
     secretKeysLoadedRef.current = null
     onClose()
   }
@@ -368,6 +371,7 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
   // Handler when user confirms re-map from the prompt modal
   const handleRemapConfirm = async () => {
     setIsRemapping(true)
+    setRemapError(null)
     try {
       const result = await remapAssetMappings({
         class_name: className,
@@ -386,16 +390,8 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
       handleClose()
     } catch (err) {
       console.error('Failed to re-map asset mappings:', err)
-      if (displayToast) {
-        displayToast({
-          title: 'Re-map Failed',
-          body: `Failed to re-map crypto mappings: ${err.message}`,
-          color: 'danger',
-          icon: cilChartLine,
-        })
-      }
-      setShowRemapPrompt(false)
-      handleClose()
+      // Store error for display in the modal with retry option
+      setRemapError(err.message || 'Re-map operation failed. Please try again.')
     } finally {
       setIsRemapping(false)
     }
@@ -1034,6 +1030,8 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
         onDecline={handleRemapDecline}
         isProcessing={isRemapping}
         className={className}
+        error={remapError}
+        onRetry={handleRemapConfirm}
       />
     </CModal>
   )

--- a/web/src/views/registry/ProviderConfigModal.js
+++ b/web/src/views/registry/ProviderConfigModal.js
@@ -27,7 +27,7 @@ import {
 } from '@coreui/react-pro'
 import CIcon from '@coreui/icons-react'
 import { cilSettings, cilLockLocked, cilChartLine, cilClock, cilStorage } from '@coreui/icons'
-import { getProviderConfig, updateProviderConfig, getAvailableQuoteCurrencies, getSecretKeys, updateSecrets } from '../services/registry_api'
+import { getProviderConfig, updateProviderConfig, getAvailableQuoteCurrencies, getSecretKeys, updateSecrets, remapAssetMappings } from '../services/registry_api'
 import RemapPromptModal from './RemapPromptModal'
 
 // Default values for live provider scheduling
@@ -368,11 +368,23 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
   // Handler when user confirms re-map from the prompt modal
   const handleRemapConfirm = async () => {
     setIsRemapping(true)
-    // T023 will wire this to actually call remapAssetMappings()
-    // For now, just close and reset
-    setIsRemapping(false)
-    setShowRemapPrompt(false)
-    handleClose()
+    try {
+      await remapAssetMappings({
+        class_name: className,
+        class_type: classType,
+        asset_class: 'crypto'
+      })
+      // T024 will add success toast notification here
+      setShowRemapPrompt(false)
+      handleClose()
+    } catch (err) {
+      console.error('Failed to re-map asset mappings:', err)
+      // T024 will add error toast notification here
+      setShowRemapPrompt(false)
+      handleClose()
+    } finally {
+      setIsRemapping(false)
+    }
   }
 
   // Handler when user declines re-map from the prompt modal

--- a/web/src/views/registry/ProviderConfigModal.js
+++ b/web/src/views/registry/ProviderConfigModal.js
@@ -369,17 +369,31 @@ const ProviderConfigModal = ({ visible, onClose, classType, className, classSubt
   const handleRemapConfirm = async () => {
     setIsRemapping(true)
     try {
-      await remapAssetMappings({
+      const result = await remapAssetMappings({
         class_name: className,
         class_type: classType,
         asset_class: 'crypto'
       })
-      // T024 will add success toast notification here
+      if (displayToast) {
+        displayToast({
+          title: 'Crypto Mappings Re-mapped',
+          body: `Successfully re-mapped crypto assets for ${className}. Deleted: ${result.deleted}, Created: ${result.created}, Skipped: ${result.skipped}.`,
+          color: 'success',
+          icon: cilChartLine,
+        })
+      }
       setShowRemapPrompt(false)
       handleClose()
     } catch (err) {
       console.error('Failed to re-map asset mappings:', err)
-      // T024 will add error toast notification here
+      if (displayToast) {
+        displayToast({
+          title: 'Re-map Failed',
+          body: `Failed to re-map crypto mappings: ${err.message}`,
+          color: 'danger',
+          icon: cilChartLine,
+        })
+      }
       setShowRemapPrompt(false)
       handleClose()
     } finally {

--- a/web/src/views/registry/Registry.js
+++ b/web/src/views/registry/Registry.js
@@ -32,7 +32,6 @@ const Registry = () => {
     try {
       const response = await getRegisteredClasses()
       setClasses(response)
-      console.log('Registered classes:', response)
     } catch (error) {
       setError(null)
       console.error('Error fetching registered classes:', error)
@@ -68,7 +67,6 @@ const Registry = () => {
   }
 
   const handleRefreshComponents = () => {
-    console.log('Refreshing components (re-fetching classes)...')
     fetchClasses()
   }
 
@@ -163,15 +161,9 @@ const Registry = () => {
     }
 
     setUploading(true)
-    console.log(`Submitting code upload for ${classType}:`, {
-      fileName: file.name,
-      secretsCount: secrets.length,
-    })
-    console.log('Secrets:', secrets)
 
     try {
       const responseData = await uploadCode(classType, file, secrets)
-      console.log('Upload successful:', responseData)
       displayToast({
         // Use displayToast
         title: 'Upload Success',

--- a/web/src/views/registry/Registry.js
+++ b/web/src/views/registry/Registry.js
@@ -1,17 +1,18 @@
 import { React, useState, useEffect, useRef } from 'react'
 import CIcon from '@coreui/icons-react'
-import { 
-  CCard, 
-  CCardBody, 
-  CCardHeader, 
-  CCol, 
-  CRow, 
-  CSpinner, 
-  CButton, 
+import {
+  CCard,
+  CCardBody,
+  CCardHeader,
+  CCol,
+  CRow,
+  CSpinner,
+  CButton,
   CToaster, // For toast notifications
   CToast,
   CToastHeader,
-  CToastBody } from '@coreui/react-pro'
+  CToastBody,
+} from '@coreui/react-pro'
 import { cilPlus, cilSync, cilLoopCircular, cilCheckCircle, cilWarning } from '@coreui/icons'
 import ClassSummaryCard from './ClassSummaryCard'
 import CodeUploadModal from './CodeUploadModal'
@@ -21,7 +22,7 @@ const Registry = () => {
   const [classes, setClasses] = useState([])
   const [loading, setLoading] = useState(true)
   const [uploading, setUploading] = useState(false) // Specific loading for upload action
-  const [refreshingAll, setRefreshingAll] = useState(false); // New state for "refresh all"
+  const [refreshingAll, setRefreshingAll] = useState(false) // New state for "refresh all"
   const [error, setError] = useState(null)
   const [isUploadModalVisible, setIsUploadModalVisible] = useState(false)
   const [toastToShow, setToastToShow] = useState(null) // New state for the toast element
@@ -35,7 +36,7 @@ const Registry = () => {
     } catch (error) {
       setError(null)
       console.error('Error fetching registered classes:', error)
-      setError("Failed to fetch registered classes.")
+      setError('Failed to fetch registered classes.')
       setClasses([])
     } finally {
       setLoading(false)
@@ -47,7 +48,7 @@ const Registry = () => {
     fetchClasses()
   }, [])
 
-    // Helper function to add toasts
+  // Helper function to add toasts
   const displayToast = (toastConfig) => {
     const newToast = (
       <CToast
@@ -72,35 +73,41 @@ const Registry = () => {
   }
 
   const handleRefreshAllAssets = async () => {
-    setRefreshingAll(true);
-    displayToast({ title: 'Refreshing All Assets', body: 'Starting update for all registered classes...', color: 'info' });
+    setRefreshingAll(true)
+    displayToast({
+      title: 'Refreshing All Assets',
+      body: 'Starting update for all registered classes...',
+      color: 'info',
+    })
     try {
-      const results = await updateAllAssets(); // This returns a list of stats or a single message
+      const results = await updateAllAssets() // This returns a list of stats or a single message
       // console.log('Refresh all assets successful:', results); // For debugging
 
       // Process the results to give a summary toast
       // The backend returns a list of stats for each provider, or a single message if no providers.
-      let successCount = 0;
-      let failCount = 0;
-      let totalAdded = 0;
-      let totalUpdated = 0;
-      let messageBody = '';
+      let successCount = 0
+      let failCount = 0
+      let totalAdded = 0
+      let totalUpdated = 0
+      let messageBody = ''
 
       if (Array.isArray(results)) {
-        results.forEach(stat => {
-          if (stat.status === 200 || stat.status === 204) { // 204 for "no symbols" is a success for that provider
-            successCount++;
-            totalAdded += stat.added_symbols || 0;
-            totalUpdated += stat.updated_symbols || 0;
+        results.forEach((stat) => {
+          if (stat.status === 200 || stat.status === 204) {
+            // 204 for "no symbols" is a success for that provider
+            successCount++
+            totalAdded += stat.added_symbols || 0
+            totalUpdated += stat.updated_symbols || 0
           } else {
-            failCount++;
+            failCount++
           }
-        });
-        messageBody = `${successCount} classes processed successfully, ${failCount} failed. Total assets added: ${totalAdded}, updated: ${totalUpdated}.`;
-      } else if (results && results.message) { // Handle cases like "No registered providers found."
-         messageBody = results.message;
+        })
+        messageBody = `${successCount} classes processed successfully, ${failCount} failed. Total assets added: ${totalAdded}, updated: ${totalUpdated}.`
+      } else if (results && results.message) {
+        // Handle cases like "No registered providers found."
+        messageBody = results.message
       } else {
-        messageBody = 'Asset refresh process completed.';
+        messageBody = 'Asset refresh process completed.'
       }
 
       displayToast({
@@ -108,18 +115,18 @@ const Registry = () => {
         body: messageBody,
         color: failCount > 0 ? 'warning' : 'success',
         icon: failCount > 0 ? cilWarning : cilCheckCircle,
-      });
-      fetchClasses(); // Refresh the list to update counts on cards
+      })
+      fetchClasses() // Refresh the list to update counts on cards
     } catch (err) {
-      console.error('Error refreshing all assets:', err);
+      console.error('Error refreshing all assets:', err)
       displayToast({
         title: 'Refresh All Failed',
         body: err.message || 'An error occurred while refreshing all assets.',
         color: 'danger',
         icon: cilWarning,
-      });
+      })
     } finally {
-      setRefreshingAll(false);
+      setRefreshingAll(false)
     }
   }
 
@@ -128,7 +135,8 @@ const Registry = () => {
   }
 
   const handleUploadModalClose = () => {
-    if (!uploading) { // Prevent closing if an upload is in progress
+    if (!uploading) {
+      // Prevent closing if an upload is in progress
       setIsUploadModalVisible(false)
     }
   }
@@ -136,22 +144,36 @@ const Registry = () => {
   // Updated handleUploadSubmit
   const handleUploadSubmit = async ({ file, secrets, classType }) => {
     if (!file) {
-      displayToast({ title: 'Upload Error', body: 'No file selected for upload.', color: 'danger', icon: cilWarning }); // Use displayToast
-      return;
+      displayToast({
+        title: 'Upload Error',
+        body: 'No file selected for upload.',
+        color: 'danger',
+        icon: cilWarning,
+      }) // Use displayToast
+      return
     }
     if (!classType) {
-      displayToast({ title: 'Upload Error', body: 'No class type selected.', color: 'danger', icon: cilWarning }); // Use displayToast
-      return;
+      displayToast({
+        title: 'Upload Error',
+        body: 'No class type selected.',
+        color: 'danger',
+        icon: cilWarning,
+      }) // Use displayToast
+      return
     }
 
     setUploading(true)
-    console.log(`Submitting code upload for ${classType}:`, { fileName: file.name, secretsCount: secrets.length });
+    console.log(`Submitting code upload for ${classType}:`, {
+      fileName: file.name,
+      secretsCount: secrets.length,
+    })
     console.log('Secrets:', secrets)
 
     try {
       const responseData = await uploadCode(classType, file, secrets)
       console.log('Upload successful:', responseData)
-      displayToast({ // Use displayToast
+      displayToast({
+        // Use displayToast
         title: 'Upload Success',
         body: responseData.message || responseData.status || 'Code uploaded successfully!',
         color: 'success',
@@ -161,7 +183,8 @@ const Registry = () => {
       setIsUploadModalVisible(false)
     } catch (uploadError) {
       console.error('Upload failed:', uploadError)
-      displayToast({ // Use displayToast
+      displayToast({
+        // Use displayToast
         title: 'Upload Failed',
         body: uploadError.message || 'An error occurred during upload.',
         color: 'danger',
@@ -227,14 +250,29 @@ const Registry = () => {
               ) : classes.length === 0 ? (
                 <div className="text-center">No registered code found.</div>
               ) : (
-                <CRow xs={{ cols: 1 }} sm={{ cols: 1 }} md={{ cols: 2 }} lg={{ cols: 3 }} xl={{ cols: 3 }} xxl={{cols: 4}} className="g-4">                {classes.map((class_summary_item) => (
+                <CRow
+                  xs={{ cols: 1 }}
+                  sm={{ cols: 1 }}
+                  md={{ cols: 2 }}
+                  lg={{ cols: 3 }}
+                  xl={{ cols: 3 }}
+                  xxl={{ cols: 4 }}
+                  className="g-4"
+                >
+                  {' '}
+                  {classes.map((class_summary_item) => (
                     // Each ClassSummaryCard is wrapped in its own CCol for grid layout
-                    <CCol key={class_summary_item.class_name || class_summary_item.id /* Ensure unique key */}>
-                      <ClassSummaryCard 
+                    <CCol
+                      key={
+                        class_summary_item.class_name ||
+                        class_summary_item.id /* Ensure unique key */
+                      }
+                    >
+                      <ClassSummaryCard
                         class_summary={class_summary_item}
                         displayToast={displayToast}
                         onAssetsRefreshed={fetchClasses} // Callback to refresh classes
-                       />
+                      />
                     </CCol>
                   ))}
                 </CRow>

--- a/web/src/views/registry/RemapPromptModal.js
+++ b/web/src/views/registry/RemapPromptModal.js
@@ -10,7 +10,7 @@ import {
   CSpinner,
 } from '@coreui/react-pro'
 import CIcon from '@coreui/icons-react'
-import { cilSync, cilInfo } from '@coreui/icons'
+import { cilSync, cilInfo, cilXCircle } from '@coreui/icons'
 
 /**
  * RemapPromptModal - A simple Yes/No prompt that appears after changing crypto quote currency.
@@ -23,6 +23,8 @@ const RemapPromptModal = ({
   onDecline,
   isProcessing,
   className,
+  error,
+  onRetry,
 }) => {
   const handleDecline = () => {
     if (onDecline) {
@@ -46,32 +48,97 @@ const RemapPromptModal = ({
     >
       <CModalHeader>
         <CModalTitle>
-          <CIcon icon={cilSync} className="me-2" />
-          Re-map Crypto Assets?
+          {error ? (
+            <>
+              <CIcon icon={cilXCircle} className="me-2" style={{ color: 'var(--cui-danger)' }} />
+              Re-map Failed
+            </>
+          ) : (
+            <>
+              <CIcon icon={cilSync} className="me-2" />
+              Re-map Crypto Assets?
+            </>
+          )}
         </CModalTitle>
       </CModalHeader>
       <CModalBody>
-        <div className="d-flex align-items-start mb-3">
-          <CIcon icon={cilInfo} className="text-info me-3 mt-1 flex-shrink-0" size="lg" />
-          <div>
-            <p className="mb-2">
-              You changed the preferred quote currency for <strong>{className}</strong>.
-            </p>
+        {/* Error display - shown when re-map fails */}
+        {error && (
+          <div
+            className="p-3 rounded mb-3"
+            style={{ backgroundColor: 'var(--cui-danger-bg-subtle)' }}
+          >
+            <div className="d-flex align-items-center mb-2">
+              <CIcon
+                icon={cilXCircle}
+                size="xl"
+                className="me-2 flex-shrink-0"
+                style={{ color: 'var(--cui-danger)' }}
+              />
+              <span className="fw-semibold" style={{ color: 'var(--cui-danger)' }}>
+                Re-map operation failed
+              </span>
+            </div>
             <p className="mb-0 text-body-secondary">
-              Would you like to re-map crypto asset mappings to use the new quote currency preference?
-              This will delete existing crypto mappings and regenerate them with the new preference.
+              {error}
+            </p>
+            <p className="mb-0 mt-2 small text-body-secondary">
+              The operation has been rolled back. No mappings were modified.
             </p>
           </div>
-        </div>
+        )}
+
+        {/* Normal prompt view - shown when no error */}
+        {!error && (
+          <div className="d-flex align-items-start mb-3">
+            <CIcon icon={cilInfo} className="text-info me-3 mt-1 flex-shrink-0" size="lg" />
+            <div>
+              <p className="mb-2">
+                You changed the preferred quote currency for <strong>{className}</strong>.
+              </p>
+              <p className="mb-0 text-body-secondary">
+                Would you like to re-map crypto asset mappings to use the new quote currency preference?
+                This will delete existing crypto mappings and regenerate them with the new preference.
+              </p>
+            </div>
+          </div>
+        )}
       </CModalBody>
       <CModalFooter>
-        <CButton color="secondary" onClick={handleDecline} disabled={isProcessing}>
-          No, Later
-        </CButton>
-        <CButton color="primary" onClick={handleConfirm} disabled={isProcessing}>
-          {isProcessing ? <CSpinner size="sm" className="me-1" /> : null}
-          {isProcessing ? 'Re-mapping...' : 'Yes, Re-map Now'}
-        </CButton>
+        {error ? (
+          <>
+            <CButton color="secondary" onClick={handleDecline} disabled={isProcessing}>
+              Close
+            </CButton>
+            <CButton
+              color="warning"
+              onClick={onRetry || handleConfirm}
+              disabled={isProcessing}
+            >
+              {isProcessing ? (
+                <>
+                  <CSpinner size="sm" className="me-2" />
+                  Retrying...
+                </>
+              ) : (
+                <>
+                  <CIcon icon={cilSync} className="me-2" />
+                  Retry
+                </>
+              )}
+            </CButton>
+          </>
+        ) : (
+          <>
+            <CButton color="secondary" onClick={handleDecline} disabled={isProcessing}>
+              No, Later
+            </CButton>
+            <CButton color="primary" onClick={handleConfirm} disabled={isProcessing}>
+              {isProcessing ? <CSpinner size="sm" className="me-1" /> : null}
+              {isProcessing ? 'Re-mapping...' : 'Yes, Re-map Now'}
+            </CButton>
+          </>
+        )}
       </CModalFooter>
     </CModal>
   )
@@ -84,11 +151,15 @@ RemapPromptModal.propTypes = {
   onDecline: PropTypes.func,
   isProcessing: PropTypes.bool,
   className: PropTypes.string.isRequired,
+  error: PropTypes.string,
+  onRetry: PropTypes.func,
 }
 
 RemapPromptModal.defaultProps = {
   onDecline: null,
   isProcessing: false,
+  error: null,
+  onRetry: null,
 }
 
 export default RemapPromptModal

--- a/web/src/views/registry/RemapPromptModal.js
+++ b/web/src/views/registry/RemapPromptModal.js
@@ -79,9 +79,7 @@ const RemapPromptModal = ({
                 Re-map operation failed
               </span>
             </div>
-            <p className="mb-0 text-body-secondary">
-              {error}
-            </p>
+            <p className="mb-0 text-body-secondary">{error}</p>
             <p className="mb-0 mt-2 small text-body-secondary">
               The operation has been rolled back. No mappings were modified.
             </p>
@@ -97,8 +95,9 @@ const RemapPromptModal = ({
                 You changed the preferred quote currency for <strong>{className}</strong>.
               </p>
               <p className="mb-0 text-body-secondary">
-                Would you like to re-map crypto asset mappings to use the new quote currency preference?
-                This will delete existing crypto mappings and regenerate them with the new preference.
+                Would you like to re-map crypto asset mappings to use the new quote currency
+                preference? This will delete existing crypto mappings and regenerate them with the
+                new preference.
               </p>
             </div>
           </div>
@@ -110,11 +109,7 @@ const RemapPromptModal = ({
             <CButton color="secondary" onClick={handleDecline} disabled={isProcessing}>
               Close
             </CButton>
-            <CButton
-              color="warning"
-              onClick={onRetry || handleConfirm}
-              disabled={isProcessing}
-            >
+            <CButton color="warning" onClick={onRetry || handleConfirm} disabled={isProcessing}>
               {isProcessing ? (
                 <>
                   <CSpinner size="sm" className="me-2" />

--- a/web/src/views/registry/RemapPromptModal.js
+++ b/web/src/views/registry/RemapPromptModal.js
@@ -66,7 +66,10 @@ const RemapPromptModal = ({
         {error && (
           <div
             className="p-3 rounded mb-3"
-            style={{ backgroundColor: 'var(--cui-danger-bg-subtle)' }}
+            style={{
+              backgroundColor: 'var(--cui-danger-bg-subtle)',
+              color: 'var(--cui-danger-text-emphasis)',
+            }}
           >
             <div className="d-flex align-items-center mb-2">
               <CIcon
@@ -79,8 +82,8 @@ const RemapPromptModal = ({
                 Re-map operation failed
               </span>
             </div>
-            <p className="mb-0 text-body-secondary">{error}</p>
-            <p className="mb-0 mt-2 small text-body-secondary">
+            <p className="mb-0">{error}</p>
+            <p className="mb-0 mt-2 small">
               The operation has been rolled back. No mappings were modified.
             </p>
           </div>

--- a/web/src/views/registry/RemapPromptModal.js
+++ b/web/src/views/registry/RemapPromptModal.js
@@ -1,0 +1,94 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {
+  CModal,
+  CModalHeader,
+  CModalTitle,
+  CModalBody,
+  CModalFooter,
+  CButton,
+  CSpinner,
+} from '@coreui/react-pro'
+import CIcon from '@coreui/icons-react'
+import { cilSync, cilInfo } from '@coreui/icons'
+
+/**
+ * RemapPromptModal - A simple Yes/No prompt that appears after changing crypto quote currency.
+ * Asks the user if they want to re-map crypto asset mappings to reflect the new preference.
+ */
+const RemapPromptModal = ({
+  visible,
+  onClose,
+  onConfirm,
+  onDecline,
+  isProcessing,
+  className,
+}) => {
+  const handleDecline = () => {
+    if (onDecline) {
+      onDecline()
+    }
+    onClose()
+  }
+
+  const handleConfirm = () => {
+    if (onConfirm) {
+      onConfirm()
+    }
+  }
+
+  return (
+    <CModal
+      visible={visible}
+      onClose={isProcessing ? () => {} : handleDecline}
+      backdrop="static"
+      size="md"
+    >
+      <CModalHeader>
+        <CModalTitle>
+          <CIcon icon={cilSync} className="me-2" />
+          Re-map Crypto Assets?
+        </CModalTitle>
+      </CModalHeader>
+      <CModalBody>
+        <div className="d-flex align-items-start mb-3">
+          <CIcon icon={cilInfo} className="text-info me-3 mt-1 flex-shrink-0" size="lg" />
+          <div>
+            <p className="mb-2">
+              You changed the preferred quote currency for <strong>{className}</strong>.
+            </p>
+            <p className="mb-0 text-body-secondary">
+              Would you like to re-map crypto asset mappings to use the new quote currency preference?
+              This will delete existing crypto mappings and regenerate them with the new preference.
+            </p>
+          </div>
+        </div>
+      </CModalBody>
+      <CModalFooter>
+        <CButton color="secondary" onClick={handleDecline} disabled={isProcessing}>
+          No, Later
+        </CButton>
+        <CButton color="primary" onClick={handleConfirm} disabled={isProcessing}>
+          {isProcessing ? <CSpinner size="sm" className="me-1" /> : null}
+          {isProcessing ? 'Re-mapping...' : 'Yes, Re-map Now'}
+        </CButton>
+      </CModalFooter>
+    </CModal>
+  )
+}
+
+RemapPromptModal.propTypes = {
+  visible: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  onDecline: PropTypes.func,
+  isProcessing: PropTypes.bool,
+  className: PropTypes.string.isRequired,
+}
+
+RemapPromptModal.defaultProps = {
+  onDecline: null,
+  isProcessing: false,
+}
+
+export default RemapPromptModal

--- a/web/src/views/services/datahub_api.js
+++ b/web/src/views/services/datahub_api.js
@@ -1,5 +1,5 @@
 // API base path - uses relative URL for proxy compatibility (dev: Vite proxy, prod: nginx/ALB)
-const API_BASE = '/api/datahub/';
+const API_BASE = '/api/datahub/'
 
 /**
  * Safely parse JSON response with Content-Type validation.
@@ -9,22 +9,22 @@ const API_BASE = '/api/datahub/';
  */
 const parseJSONResponse = async (response) => {
   const contentType = response.headers.get('content-type')
-  
+
   // Read response as text first (response body can only be read once)
   const text = await response.text()
-  
+
   if (!contentType || !contentType.includes('application/json')) {
     throw new Error(
-      `Expected JSON response, got ${contentType || 'unknown content type'}. Response: ${text.substring(0, 200)}`
+      `Expected JSON response, got ${contentType || 'unknown content type'}. Response: ${text.substring(0, 200)}`,
     )
   }
-  
+
   // Try to parse the text as JSON
   try {
     return JSON.parse(text)
   } catch (err) {
     throw new Error(
-      `Failed to parse JSON response: ${err.message}. Response: ${text.substring(0, 200)}`
+      `Failed to parse JSON response: ${err.message}. Response: ${text.substring(0, 200)}`,
     )
   }
 }
@@ -83,14 +83,14 @@ const validateNumber = (value, name, min, max, required = false) => {
 export const searchSymbols = async (query, options = {}) => {
   // Validate inputs
   const validatedQuery = validateString(query, 'query', true)
-  
+
   const validatedOptions = {}
   if (options.data_type !== undefined) {
     validatedOptions.data_type = validateEnum(
-      options.data_type, 
-      'data_type', 
-      ['historical', 'live'], 
-      false
+      options.data_type,
+      'data_type',
+      ['historical', 'live'],
+      false,
     )
   }
   if (options.provider !== undefined) {
@@ -102,16 +102,16 @@ export const searchSymbols = async (query, options = {}) => {
 
   const params = new URLSearchParams({
     q: validatedQuery,
-  });
+  })
 
   if (validatedOptions.data_type) {
-    params.append('data_type', validatedOptions.data_type);
+    params.append('data_type', validatedOptions.data_type)
   }
   if (validatedOptions.provider) {
-    params.append('provider', validatedOptions.provider);
+    params.append('provider', validatedOptions.provider)
   }
   if (validatedOptions.limit !== undefined) {
-    params.append('limit', validatedOptions.limit.toString());
+    params.append('limit', validatedOptions.limit.toString())
   }
 
   const response = await fetch(`${API_BASE}symbols/search?${params.toString()}`, {
@@ -119,7 +119,7 @@ export const searchSymbols = async (query, options = {}) => {
     headers: {
       'Content-Type': 'application/json',
     },
-  });
+  })
 
   let data
   try {
@@ -133,12 +133,13 @@ export const searchSymbols = async (query, options = {}) => {
   }
 
   if (!response.ok) {
-    const errorMessage = data.detail || data.error || data.message || `HTTP error! status: ${response.status}`;
-    throw new Error(errorMessage);
+    const errorMessage =
+      data.detail || data.error || data.message || `HTTP error! status: ${response.status}`
+    throw new Error(errorMessage)
   }
 
-  return data;
-};
+  return data
+}
 
 /**
  * Retrieve OHLC data for a specific symbol/provider combination.
@@ -159,7 +160,7 @@ export const getOHLCData = async (provider, symbol, dataType, interval, options 
   const validatedSymbol = validateString(symbol, 'symbol', true)
   const validatedDataType = validateEnum(dataType, 'data_type', ['historical', 'live'], true)
   const validatedInterval = validateString(interval, 'interval', true)
-  
+
   // Validate optional inputs
   const validatedOptions = {}
   if (options.limit !== undefined) {
@@ -181,19 +182,19 @@ export const getOHLCData = async (provider, symbol, dataType, interval, options 
     symbol: validatedSymbol,
     data_type: validatedDataType,
     interval: validatedInterval,
-  });
+  })
 
   if (validatedOptions.limit !== undefined) {
-    params.append('limit', validatedOptions.limit.toString());
+    params.append('limit', validatedOptions.limit.toString())
   }
   if (validatedOptions.from_time !== undefined) {
-    params.append('from', validatedOptions.from_time.toString());
+    params.append('from', validatedOptions.from_time.toString())
   }
   if (validatedOptions.to_time !== undefined) {
-    params.append('to', validatedOptions.to_time.toString());
+    params.append('to', validatedOptions.to_time.toString())
   }
   if (validatedOptions.order) {
-    params.append('order', validatedOptions.order);
+    params.append('order', validatedOptions.order)
   }
 
   const response = await fetch(`${API_BASE}data?${params.toString()}`, {
@@ -201,7 +202,7 @@ export const getOHLCData = async (provider, symbol, dataType, interval, options 
     headers: {
       'Content-Type': 'application/json',
     },
-  });
+  })
 
   let data
   try {
@@ -215,12 +216,13 @@ export const getOHLCData = async (provider, symbol, dataType, interval, options 
   }
 
   if (!response.ok) {
-    const errorMessage = data.detail || data.error || data.message || `HTTP error! status: ${response.status}`;
-    throw new Error(errorMessage);
+    const errorMessage =
+      data.detail || data.error || data.message || `HTTP error! status: ${response.status}`
+    throw new Error(errorMessage)
   }
 
-  return data;
-};
+  return data
+}
 
 /**
  * Get detailed metadata for a specific symbol/provider combination.
@@ -233,27 +235,27 @@ export const getSymbolMetadata = async (provider, symbol, dataType = null) => {
   // Validate required inputs
   const validatedProvider = validateString(provider, 'provider', true)
   const validatedSymbol = validateString(symbol, 'symbol', true)
-  
+
   // Validate optional dataType
   if (dataType !== null && dataType !== undefined) {
     validateEnum(dataType, 'data_type', ['historical', 'live'], false)
   }
 
-  const params = new URLSearchParams();
+  const params = new URLSearchParams()
 
   if (dataType) {
-    params.append('data_type', dataType);
+    params.append('data_type', dataType)
   }
 
-  const queryString = params.toString();
-  const url = `${API_BASE}symbols/${encodeURIComponent(validatedProvider)}/${encodeURIComponent(validatedSymbol)}${queryString ? `?${queryString}` : ''}`;
+  const queryString = params.toString()
+  const url = `${API_BASE}symbols/${encodeURIComponent(validatedProvider)}/${encodeURIComponent(validatedSymbol)}${queryString ? `?${queryString}` : ''}`
 
   const response = await fetch(url, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
     },
-  });
+  })
 
   let data
   try {
@@ -267,10 +269,10 @@ export const getSymbolMetadata = async (provider, symbol, dataType = null) => {
   }
 
   if (!response.ok) {
-    const errorMessage = data.detail || data.error || data.message || `HTTP error! status: ${response.status}`;
-    throw new Error(errorMessage);
+    const errorMessage =
+      data.detail || data.error || data.message || `HTTP error! status: ${response.status}`
+    throw new Error(errorMessage)
   }
 
-  return data;
-};
-
+  return data
+}

--- a/web/src/views/services/registry_api.js
+++ b/web/src/views/services/registry_api.js
@@ -912,8 +912,7 @@ export const getRemapPreview = async (params = {}) => {
   const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage =
-      data.detail || data.error || data.message || `HTTP error! status: ${response.status}`
+    const errorMessage = formatErrorMessage(data, response.status)
     throw new Error(errorMessage)
   }
 
@@ -941,8 +940,7 @@ export const remapAssetMappings = async (params = {}) => {
   const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage =
-      data.detail || data.error || data.message || `HTTP error! status: ${response.status}`
+    const errorMessage = formatErrorMessage(data, response.status)
     throw new Error(errorMessage)
   }
 

--- a/web/src/views/services/registry_api.js
+++ b/web/src/views/services/registry_api.js
@@ -362,8 +362,6 @@ export const getAssets = async (params = {}) => {
   const queryString = queryParams.toString()
   const url = `${API_BASE}assets${queryString ? `?${queryString}` : ''}`
 
-  console.log('Fetching assets with URL:', url) // For debugging
-
   const response = await fetch(url, {
     method: 'GET',
     headers: {

--- a/web/src/views/services/registry_api.js
+++ b/web/src/views/services/registry_api.js
@@ -1,178 +1,178 @@
 // API base path - uses relative URL for proxy compatibility (dev: Vite proxy, prod: nginx/ALB)
-const API_BASE = '/api/registry/';
+const API_BASE = '/api/registry/'
 
 // Normalize backend error payloads (objects/arrays) into a readable string
 const formatErrorMessage = (data, status) => {
   if (!data) {
-    return `HTTP error! status: ${status}`;
+    return `HTTP error! status: ${status}`
   }
-  const detail = data.detail || data.error || data.message;
+  const detail = data.detail || data.error || data.message
   if (Array.isArray(detail)) {
     return detail
       .map((item) => {
-        if (typeof item === 'string') return item;
-        if (item?.msg) return item.msg;
-        if (item?.message) return item.message;
-        return JSON.stringify(item);
+        if (typeof item === 'string') return item
+        if (item?.msg) return item.msg
+        if (item?.message) return item.message
+        return JSON.stringify(item)
       })
-      .join('; ');
+      .join('; ')
   }
   if (typeof detail === 'object') {
-    if (detail?.msg) return detail.msg;
-    if (detail?.message) return detail.message;
-    return JSON.stringify(detail);
+    if (detail?.msg) return detail.msg
+    if (detail?.message) return detail.message
+    return JSON.stringify(detail)
   }
-  return detail || `HTTP error! status: ${status}`;
-};
+  return detail || `HTTP error! status: ${status}`
+}
 
 export const updateAssetsForClass = async (classType, className) => {
-    const params = new URLSearchParams({
-        class_type: classType,
-        class_name: className
-    });
-    
-    const response = await fetch(`${API_BASE}update-assets?${params.toString()}`, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-        },
-    });
-    const data = await response.json();
+  const params = new URLSearchParams({
+    class_type: classType,
+    class_name: className,
+  })
 
+  const response = await fetch(`${API_BASE}update-assets?${params.toString()}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+  const data = await response.json()
 
-    if (!response.ok) {
-        // Use message from data if available, otherwise use a generic error
-        const errorMessage = data.error || data.message || `HTTP error! status: ${response.status}`;
-        throw new Error(errorMessage);
-    }
+  if (!response.ok) {
+    // Use message from data if available, otherwise use a generic error
+    const errorMessage = data.error || data.message || `HTTP error! status: ${response.status}`
+    throw new Error(errorMessage)
+  }
 
-    return data;
+  return data
 }
 
 export const updateAllAssets = async () => {
-    const response = await fetch(`${API_BASE}update-all-assets`, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-        },
-    });
-    const data = await response.json();
+  const response = await fetch(`${API_BASE}update-all-assets`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+  const data = await response.json()
 
+  if (!response.ok) {
+    // Use message from data if available, otherwise use a generic error
+    const errorMessage = data.error || data.message || `HTTP error! status: ${response.status}`
+    throw new Error(errorMessage)
+  }
 
-    if (!response.ok) {
-        // Use message from data if available, otherwise use a generic error
-        const errorMessage = data.error || data.message || `HTTP error! status: ${response.status}`;
-        throw new Error(errorMessage);
-    }
-
-    return data;
+  return data
 }
 export const getRegisteredClasses = async () => {
-    const response = await fetch(`${API_BASE}classes/summary`, {
-        method: 'GET',
-        headers: {
-            'Content-Type': 'application/json',
-        },
-    });
-    const data = await response.json();
+  const response = await fetch(`${API_BASE}classes/summary`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+  const data = await response.json()
 
-    if (!response.ok) {
-        // Use message from data if available, otherwise use a generic error
-        const errorMessage = data.error || data.message || `HTTP error! status: ${response.status}`;
-        throw new Error(errorMessage);
-    }
+  if (!response.ok) {
+    // Use message from data if available, otherwise use a generic error
+    const errorMessage = data.error || data.message || `HTTP error! status: ${response.status}`
+    throw new Error(errorMessage)
+  }
 
-    return data;
+  return data
 }
 export const uploadCode = async (classType, file, secretsObject) => {
-  const formData = new FormData();
-  formData.append('file', file, file.name); // The third argument is the filename
+  const formData = new FormData()
+  formData.append('file', file, file.name) // The third argument is the filename
 
   // Convert secrets array to a JSON string to send as a single field.
-  const secretsString = JSON.stringify(secretsObject);
-  formData.append('secrets', secretsString);
+  const secretsString = JSON.stringify(secretsObject)
+  formData.append('secrets', secretsString)
 
   const params = new URLSearchParams({
-    class_type: classType
-  });
+    class_type: classType,
+  })
 
   const response = await fetch(`${API_BASE}upload?${params.toString()}`, {
     method: 'POST',
     body: formData,
-  });
+  })
 
-  const responseData = await response.json();
+  const responseData = await response.json()
 
   if (!response.ok) {
     // Use message from responseData if available, otherwise use a generic error
-    const errorMessage = responseData.error || responseData.message || `HTTP error! status: ${response.status}`;
-    throw new Error(errorMessage);
+    const errorMessage =
+      responseData.error || responseData.message || `HTTP error! status: ${response.status}`
+    throw new Error(errorMessage)
   }
 
-  return responseData;
-};
+  return responseData
+}
 export const deleteRegisteredClass = async (classType, className) => {
   const params = new URLSearchParams({
     class_type: classType,
-    class_name: className
-  });
-  
+    class_name: className,
+  })
+
   const response = await fetch(`${API_BASE}delete?${params.toString()}`, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json', // Optional for DELETE if no body, but good practice
     },
-  });
+  })
 
   // DELETE requests might not always return a body, or might return an empty body on success (204 No Content)
   // Or they might return a JSON body with a success/error message.
-  let responseData;
-  const contentType = response.headers.get("content-type");
-  if (contentType && contentType.indexOf("application/json") !== -1) {
-    responseData = await response.json();
+  let responseData
+  const contentType = response.headers.get('content-type')
+  if (contentType && contentType.indexOf('application/json') !== -1) {
+    responseData = await response.json()
   } else {
     // If no JSON body, create a default object or use the status text
-    responseData = { message: response.statusText, status: response.status };
+    responseData = { message: response.statusText, status: response.status }
   }
 
   if (!response.ok) {
-    const errorMessage = responseData.error || responseData.message || `HTTP error! status: ${response.status}`;
-    throw new Error(errorMessage);
+    const errorMessage =
+      responseData.error || responseData.message || `HTTP error! status: ${response.status}`
+    throw new Error(errorMessage)
   }
 
-  return responseData; // Contains { message: "...", class_name: "...", class_type: "..." } on success
-                       // or { message: "...", ..., file_deletion_error: "..." } on partial success (207)
-                       // or throws an error with { error: "..." }
-};
+  return responseData // Contains { message: "...", class_name: "...", class_type: "..." } on success
+  // or { message: "...", ..., file_deletion_error: "..." } on partial success (207)
+  // or throws an error with { error: "..." }
+}
 
 export const getAssetMappings = async (params = {}) => {
-  const queryParams = new URLSearchParams();
+  const queryParams = new URLSearchParams()
 
   // Add only defined parameters to the query string
   Object.entries(params).forEach(([key, value]) => {
     if (value !== undefined && value !== null && String(value).trim() !== '') {
-      queryParams.append(key, value);
+      queryParams.append(key, value)
     }
-  });
+  })
 
-  const queryString = queryParams.toString();
-  const url = `${API_BASE}asset-mappings${queryString ? `?${queryString}` : ''}`;
+  const queryString = queryParams.toString()
+  const url = `${API_BASE}asset-mappings${queryString ? `?${queryString}` : ''}`
 
   const response = await fetch(url, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
     },
-  });
+  })
 
-  const data = await response.json();
+  const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage = data.error || data.message || `HTTP error! status: ${response.status}`;
-    throw new Error(errorMessage);
+    const errorMessage = data.error || data.message || `HTTP error! status: ${response.status}`
+    throw new Error(errorMessage)
   }
 
-  return data; // Now returns { items: [], total_items: X, limit: Y, offset: Z, page: P, total_pages: Q }
+  return data // Now returns { items: [], total_items: X, limit: Y, offset: Z, page: P, total_pages: Q }
 }
 
 /**
@@ -190,33 +190,34 @@ export const getAssetMappings = async (params = {}) => {
  * @returns {Promise<object>} - { items, total, limit, offset, next_cursor, has_more }
  */
 export const getAssetMappingSuggestions = async (params = {}) => {
-  const queryParams = new URLSearchParams();
+  const queryParams = new URLSearchParams()
 
   Object.entries(params).forEach(([key, value]) => {
     if (value !== undefined && value !== null && String(value).trim() !== '') {
-      queryParams.append(key, value);
+      queryParams.append(key, value)
     }
-  });
+  })
 
-  const queryString = queryParams.toString();
-  const url = `${API_BASE}asset-mapping-suggestions${queryString ? `?${queryString}` : ''}`;
+  const queryString = queryParams.toString()
+  const url = `${API_BASE}asset-mapping-suggestions${queryString ? `?${queryString}` : ''}`
 
   const response = await fetch(url, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
     },
-  });
+  })
 
-  const data = await response.json();
+  const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage = data.detail || data.error || data.message || `HTTP error! status: ${response.status}`;
-    throw new Error(errorMessage);
+    const errorMessage =
+      data.detail || data.error || data.message || `HTTP error! status: ${response.status}`
+    throw new Error(errorMessage)
   }
 
-  return data;
-};
+  return data
+}
 
 /**
  * Creates one or more asset mappings.
@@ -225,7 +226,7 @@ export const getAssetMappingSuggestions = async (params = {}) => {
  * @returns {Promise<object[]>} - The created mapping responses.
  */
 export const createAssetMapping = async (mappingData) => {
-  const payload = Array.isArray(mappingData) ? mappingData : [mappingData];
+  const payload = Array.isArray(mappingData) ? mappingData : [mappingData]
 
   const response = await fetch(`${API_BASE}asset-mappings`, {
     method: 'POST',
@@ -233,16 +234,16 @@ export const createAssetMapping = async (mappingData) => {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(payload),
-  });
+  })
 
-  const data = await response.json();
+  const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage = formatErrorMessage(data, response.status);
-    throw new Error(errorMessage);
+    const errorMessage = formatErrorMessage(data, response.status)
+    throw new Error(errorMessage)
   }
 
-  return data;
+  return data
 }
 
 /**
@@ -259,28 +260,26 @@ export const updateAssetMapping = async (class_name, class_type, class_symbol, u
   const params = new URLSearchParams({
     class_name: class_name,
     class_type: class_type,
-    class_symbol: class_symbol
-  });
-  
-  const response = await fetch(
-    `${API_BASE}asset-mappings?${params.toString()}`,
-    {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(updateData),
-    }
-  );
+    class_symbol: class_symbol,
+  })
 
-  const data = await response.json();
+  const response = await fetch(`${API_BASE}asset-mappings?${params.toString()}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(updateData),
+  })
+
+  const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage = data.detail || data.error || data.message || `HTTP error! status: ${response.status}`;
-    throw new Error(errorMessage);
+    const errorMessage =
+      data.detail || data.error || data.message || `HTTP error! status: ${response.status}`
+    throw new Error(errorMessage)
   }
 
-  return data;
+  return data
 }
 
 /**
@@ -294,41 +293,42 @@ export const deleteAssetMapping = async (class_name, class_type, class_symbol) =
   const params = new URLSearchParams({
     class_name: class_name,
     class_type: class_type,
-    class_symbol: class_symbol
-  });
-  
-  const response = await fetch(
-    `${API_BASE}asset-mappings?${params.toString()}`,
-    {
-      method: 'DELETE',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    }
-  );
+    class_symbol: class_symbol,
+  })
+
+  const response = await fetch(`${API_BASE}asset-mappings?${params.toString()}`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
 
   // DELETE requests might return 204 No Content (no body) or a JSON error
   // Check for 204 status FIRST before attempting to parse JSON
   if (response.status === 204) {
     // 204 No Content - successful deletion, no body
-    return;
+    return
   }
 
-  let responseData;
-  const contentType = response.headers.get("content-type");
-  if (contentType && contentType.indexOf("application/json") !== -1) {
-    responseData = await response.json();
+  let responseData
+  const contentType = response.headers.get('content-type')
+  if (contentType && contentType.indexOf('application/json') !== -1) {
+    responseData = await response.json()
   } else {
     // If no JSON body, create a default object
-    responseData = { message: response.statusText, status: response.status };
+    responseData = { message: response.statusText, status: response.status }
   }
 
   if (!response.ok) {
-    const errorMessage = responseData.detail || responseData.error || responseData.message || `HTTP error! status: ${response.status}`;
-    throw new Error(errorMessage);
+    const errorMessage =
+      responseData.detail ||
+      responseData.error ||
+      responseData.message ||
+      `HTTP error! status: ${response.status}`
+    throw new Error(errorMessage)
   }
 
-  return responseData;
+  return responseData
 }
 
 /**
@@ -350,37 +350,37 @@ export const deleteAssetMapping = async (class_name, class_type, class_symbol) =
  * @returns {Promise<object>} - The API response (e.g., { items: [], total_items: 0, ... }).
  */
 export const getAssets = async (params = {}) => {
-  const queryParams = new URLSearchParams();
+  const queryParams = new URLSearchParams()
 
   // Add only defined parameters to the query string
   Object.entries(params).forEach(([key, value]) => {
     if (value !== undefined && value !== null && String(value).trim() !== '') {
-      queryParams.append(key, value);
+      queryParams.append(key, value)
     }
-  });
+  })
 
-  const queryString = queryParams.toString();
-  const url = `${API_BASE}assets${queryString ? `?${queryString}` : ''}`;
+  const queryString = queryParams.toString()
+  const url = `${API_BASE}assets${queryString ? `?${queryString}` : ''}`
 
-  console.log('Fetching assets with URL:', url); // For debugging
+  console.log('Fetching assets with URL:', url) // For debugging
 
   const response = await fetch(url, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
     },
-  });
+  })
 
-  const data = await response.json();
+  const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage = data.error || data.message || `HTTP error! status: ${response.status}`;
-    console.error('Error fetching assets:', errorMessage, 'Response data:', data);
-    throw new Error(errorMessage);
+    const errorMessage = data.error || data.message || `HTTP error! status: ${response.status}`
+    console.error('Error fetching assets:', errorMessage, 'Response data:', data)
+    throw new Error(errorMessage)
   }
 
-  return data; // Expected format: { items: [], total_items: X, limit: Y, offset: Z, ... }
-};
+  return data // Expected format: { items: [], total_items: X, limit: Y, offset: Z, ... }
+}
 
 /**
  * Fetches the configuration schema for a provider.
@@ -392,25 +392,26 @@ export const getAssets = async (params = {}) => {
 export const getConfigSchema = async (classType, className) => {
   const params = new URLSearchParams({
     class_type: classType,
-    class_name: className
-  });
+    class_name: className,
+  })
 
   const response = await fetch(`${API_BASE}config/schema?${params.toString()}`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
     },
-  });
+  })
 
-  const data = await response.json();
+  const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage = data.detail || data.error || data.message || `HTTP error! status: ${response.status}`;
-    throw new Error(errorMessage);
+    const errorMessage =
+      data.detail || data.error || data.message || `HTTP error! status: ${response.status}`
+    throw new Error(errorMessage)
   }
 
-  return data;
-};
+  return data
+}
 
 /**
  * Fetches provider configuration preferences.
@@ -421,25 +422,26 @@ export const getConfigSchema = async (classType, className) => {
 export const getProviderConfig = async (classType, className) => {
   const params = new URLSearchParams({
     class_type: classType,
-    class_name: className
-  });
+    class_name: className,
+  })
 
   const response = await fetch(`${API_BASE}config?${params.toString()}`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
     },
-  });
+  })
 
-  const data = await response.json();
+  const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage = data.detail || data.error || data.message || `HTTP error! status: ${response.status}`;
-    throw new Error(errorMessage);
+    const errorMessage =
+      data.detail || data.error || data.message || `HTTP error! status: ${response.status}`
+    throw new Error(errorMessage)
   }
 
-  return data;
-};
+  return data
+}
 
 /**
  * Updates provider configuration preferences.
@@ -451,8 +453,8 @@ export const getProviderConfig = async (classType, className) => {
 export const updateProviderConfig = async (classType, className, config) => {
   const params = new URLSearchParams({
     class_type: classType,
-    class_name: className
-  });
+    class_name: className,
+  })
 
   const response = await fetch(`${API_BASE}config?${params.toString()}`, {
     method: 'PUT',
@@ -460,17 +462,17 @@ export const updateProviderConfig = async (classType, className, config) => {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(config),
-  });
+  })
 
-  const data = await response.json();
+  const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage = formatErrorMessage(data, response.status);
-    throw new Error(errorMessage);
+    const errorMessage = formatErrorMessage(data, response.status)
+    throw new Error(errorMessage)
   }
 
-  return data;
-};
+  return data
+}
 
 /**
  * Fetches secret key names for a provider (not the values).
@@ -482,25 +484,26 @@ export const updateProviderConfig = async (classType, className, config) => {
 export const getSecretKeys = async (classType, className) => {
   const params = new URLSearchParams({
     class_type: classType,
-    class_name: className
-  });
+    class_name: className,
+  })
 
   const response = await fetch(`${API_BASE}config/secret-keys?${params.toString()}`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
     },
-  });
+  })
 
-  const data = await response.json();
+  const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage = data.detail || data.error || data.message || `HTTP error! status: ${response.status}`;
-    throw new Error(errorMessage);
+    const errorMessage =
+      data.detail || data.error || data.message || `HTTP error! status: ${response.status}`
+    throw new Error(errorMessage)
   }
 
-  return data;
-};
+  return data
+}
 
 /**
  * Updates stored credentials for a provider (all-or-nothing replacement).
@@ -513,8 +516,8 @@ export const getSecretKeys = async (classType, className) => {
 export const updateSecrets = async (classType, className, secrets) => {
   const params = new URLSearchParams({
     class_type: classType,
-    class_name: className
-  });
+    class_name: className,
+  })
 
   const response = await fetch(`${API_BASE}config/secrets?${params.toString()}`, {
     method: 'PATCH',
@@ -522,17 +525,18 @@ export const updateSecrets = async (classType, className, secrets) => {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({ secrets }),
-  });
+  })
 
-  const data = await response.json();
+  const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage = data.detail || data.error || data.message || `HTTP error! status: ${response.status}`;
-    throw new Error(errorMessage);
+    const errorMessage =
+      data.detail || data.error || data.message || `HTTP error! status: ${response.status}`
+    throw new Error(errorMessage)
   }
 
-  return data;
-};
+  return data
+}
 
 /**
  * Fetches available quote currencies for a provider's crypto assets.
@@ -543,26 +547,29 @@ export const updateSecrets = async (classType, className, secrets) => {
 export const getAvailableQuoteCurrencies = async (classType, className) => {
   const params = new URLSearchParams({
     class_type: classType,
-    class_name: className
-  });
+    class_name: className,
+  })
 
-  const response = await fetch(`${API_BASE}config/available-quote-currencies?${params.toString()}`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
+  const response = await fetch(
+    `${API_BASE}config/available-quote-currencies?${params.toString()}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
     },
-  });
+  )
 
-  const data = await response.json();
+  const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage = data.detail || data.error || data.message || `HTTP error! status: ${response.status}`;
-    throw new Error(errorMessage);
+    const errorMessage =
+      data.detail || data.error || data.message || `HTTP error! status: ${response.status}`
+    throw new Error(errorMessage)
   }
 
-  return data;
-};
-
+  return data
+}
 
 /**
  * Fetches common symbols with server-side pagination, sorting, and filtering.
@@ -575,36 +582,35 @@ export const getAvailableQuoteCurrencies = async (classType, className) => {
  * @returns {Promise<object>} - Common symbols response: { items, total_items, limit, offset, page, total_pages }
  */
 export const getCommonSymbols = async (params = {}) => {
-  const queryParams = new URLSearchParams();
+  const queryParams = new URLSearchParams()
 
   // Add only defined parameters to the query string
   Object.entries(params).forEach(([key, value]) => {
     if (value !== undefined && value !== null && String(value).trim() !== '') {
-      queryParams.append(key, value);
+      queryParams.append(key, value)
     }
-  });
+  })
 
-  const queryString = queryParams.toString();
-  const url = `${API_BASE}asset-mappings/common-symbols${queryString ? `?${queryString}` : ''}`;
-
+  const queryString = queryParams.toString()
+  const url = `${API_BASE}asset-mappings/common-symbols${queryString ? `?${queryString}` : ''}`
 
   const response = await fetch(url, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
     },
-  });
+  })
 
-  const data = await response.json();
+  const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage = data.error || data.message || `HTTP error! status: ${response.status}`;
-    console.error('Error fetching common symbols:', errorMessage, 'Response data:', data);
-    throw new Error(errorMessage);
+    const errorMessage = data.error || data.message || `HTTP error! status: ${response.status}`
+    console.error('Error fetching common symbols:', errorMessage, 'Response data:', data)
+    throw new Error(errorMessage)
   }
 
-  return data; // Expected format: { items: [], total_items: X, limit: Y, offset: Z, ... }
-};
+  return data // Expected format: { items: [], total_items: X, limit: Y, offset: Z, ... }
+}
 
 /**
  * Renames a common symbol, cascading to all asset mappings and index memberships.
@@ -621,18 +627,18 @@ export const renameCommonSymbol = async (symbol, newSymbol) => {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ new_symbol: newSymbol }),
-    }
-  );
+    },
+  )
 
-  const data = await response.json();
+  const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage = formatErrorMessage(data, response.status);
-    throw new Error(errorMessage);
+    const errorMessage = formatErrorMessage(data, response.status)
+    throw new Error(errorMessage)
   }
 
-  return data;
-};
+  return data
+}
 
 /**
  * Fetches asset mappings for a specific common symbol.
@@ -645,18 +651,19 @@ export const getAssetMappingsForSymbol = async (commonSymbol) => {
     headers: {
       'Content-Type': 'application/json',
     },
-  });
+  })
 
-  const data = await response.json();
+  const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage = data.detail || data.error || data.message || `HTTP error! status: ${response.status}`;
-    console.error('Error fetching asset mappings for symbol:', errorMessage, 'Response data:', data);
-    throw new Error(errorMessage);
+    const errorMessage =
+      data.detail || data.error || data.message || `HTTP error! status: ${response.status}`
+    console.error('Error fetching asset mappings for symbol:', errorMessage, 'Response data:', data)
+    throw new Error(errorMessage)
   }
 
-  return data; // Expected format: [{ common_symbol, class_name, class_type, class_symbol, is_active }, ...]
-};
+  return data // Expected format: [{ common_symbol, class_name, class_type, class_symbol, is_active }, ...]
+}
 
 /**
  * Fetches all indices with optional filtering.
@@ -669,35 +676,35 @@ export const getAssetMappingsForSymbol = async (commonSymbol) => {
  * @returns {Promise<object>} - Indices response: { items, total_items, limit, offset }
  */
 export const getIndices = async (params = {}) => {
-  const queryParams = new URLSearchParams();
+  const queryParams = new URLSearchParams()
 
   // Default to large limit to fetch all indices for client-side pagination
-  queryParams.append('limit', params.limit || 100);
+  queryParams.append('limit', params.limit || 100)
 
   Object.entries(params).forEach(([key, value]) => {
     if (key !== 'limit' && value !== undefined && value !== null && String(value).trim() !== '') {
-      queryParams.append(key, value);
+      queryParams.append(key, value)
     }
-  });
+  })
 
-  const url = `${API_BASE}indices?${queryParams.toString()}`;
+  const url = `${API_BASE}indices?${queryParams.toString()}`
 
   const response = await fetch(url, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
     },
-  });
+  })
 
-  const data = await response.json();
+  const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage = formatErrorMessage(data, response.status);
-    throw new Error(errorMessage);
+    const errorMessage = formatErrorMessage(data, response.status)
+    throw new Error(errorMessage)
   }
 
-  return data;
-};
+  return data
+}
 
 /**
  * Fetches index detail with first 100 members.
@@ -710,17 +717,17 @@ export const getIndexDetail = async (name) => {
     headers: {
       'Content-Type': 'application/json',
     },
-  });
+  })
 
-  const data = await response.json();
+  const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage = formatErrorMessage(data, response.status);
-    throw new Error(errorMessage);
+    const errorMessage = formatErrorMessage(data, response.status)
+    throw new Error(errorMessage)
   }
 
-  return data;
-};
+  return data
+}
 
 /**
  * Fetches paginated members for an index.
@@ -733,33 +740,33 @@ export const getIndexDetail = async (name) => {
  * @returns {Promise<object>} - Members response: { items, total_items, limit, offset }
  */
 export const getIndexMembers = async (name, params = {}) => {
-  const queryParams = new URLSearchParams();
+  const queryParams = new URLSearchParams()
 
   Object.entries(params).forEach(([key, value]) => {
     if (value !== undefined && value !== null && String(value).trim() !== '') {
-      queryParams.append(key, value);
+      queryParams.append(key, value)
     }
-  });
+  })
 
-  const queryString = queryParams.toString();
-  const url = `${API_BASE}indices/${encodeURIComponent(name)}/members${queryString ? `?${queryString}` : ''}`;
+  const queryString = queryParams.toString()
+  const url = `${API_BASE}indices/${encodeURIComponent(name)}/members${queryString ? `?${queryString}` : ''}`
 
   const response = await fetch(url, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
     },
-  });
+  })
 
-  const data = await response.json();
+  const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage = formatErrorMessage(data, response.status);
-    throw new Error(errorMessage);
+    const errorMessage = formatErrorMessage(data, response.status)
+    throw new Error(errorMessage)
   }
 
-  return data;
-};
+  return data
+}
 
 /**
  * Fetches membership change history for an index (timeline view).
@@ -767,24 +774,24 @@ export const getIndexMembers = async (name, params = {}) => {
  * @returns {Promise<object>} - History response with changes grouped by date.
  */
 export const getIndexHistory = async (name) => {
-  const url = `${API_BASE}indices/${encodeURIComponent(name)}/history`;
+  const url = `${API_BASE}indices/${encodeURIComponent(name)}/history`
 
   const response = await fetch(url, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
     },
-  });
+  })
 
-  const data = await response.json();
+  const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage = formatErrorMessage(data, response.status);
-    throw new Error(errorMessage);
+    const errorMessage = formatErrorMessage(data, response.status)
+    throw new Error(errorMessage)
   }
 
-  return data;
-};
+  return data
+}
 
 /**
  * Creates a new UserIndex.
@@ -800,17 +807,17 @@ export const createUserIndex = async (data) => {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(data),
-  });
+  })
 
-  const responseData = await response.json();
+  const responseData = await response.json()
 
   if (!response.ok) {
-    const errorMessage = formatErrorMessage(responseData, response.status);
-    throw new Error(errorMessage);
+    const errorMessage = formatErrorMessage(responseData, response.status)
+    throw new Error(errorMessage)
   }
 
-  return responseData;
-};
+  return responseData
+}
 
 /**
  * Updates UserIndex members (full replacement).
@@ -828,17 +835,17 @@ export const updateUserIndexMembers = async (name, data) => {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(data),
-  });
+  })
 
-  const responseData = await response.json();
+  const responseData = await response.json()
 
   if (!response.ok) {
-    const errorMessage = formatErrorMessage(responseData, response.status);
-    throw new Error(errorMessage);
+    const errorMessage = formatErrorMessage(responseData, response.status)
+    throw new Error(errorMessage)
   }
 
-  return responseData;
-};
+  return responseData
+}
 
 /**
  * Deletes a UserIndex.
@@ -851,29 +858,29 @@ export const deleteUserIndex = async (name) => {
     headers: {
       'Content-Type': 'application/json',
     },
-  });
+  })
 
   // Handle 204 No Content (successful deletion)
   if (response.status === 204) {
-    return;
+    return
   }
 
   // If not 204, attempt to parse error response
-  let responseData;
-  const contentType = response.headers.get('content-type');
+  let responseData
+  const contentType = response.headers.get('content-type')
   if (contentType && contentType.indexOf('application/json') !== -1) {
-    responseData = await response.json();
+    responseData = await response.json()
   } else {
-    responseData = { message: response.statusText, status: response.status };
+    responseData = { message: response.statusText, status: response.status }
   }
 
   if (!response.ok) {
-    const errorMessage = formatErrorMessage(responseData, response.status);
-    throw new Error(errorMessage);
+    const errorMessage = formatErrorMessage(responseData, response.status)
+    throw new Error(errorMessage)
   }
 
-  return responseData;
-};
+  return responseData
+}
 
 /**
  * Fetches a preview of the re-map operation impact without modifying data.
@@ -884,33 +891,34 @@ export const deleteUserIndex = async (name) => {
  * @returns {Promise<object>} - Preview response: { mappings_to_delete, providers_affected, affected_indices, filter_applied }
  */
 export const getRemapPreview = async (params = {}) => {
-  const queryParams = new URLSearchParams();
+  const queryParams = new URLSearchParams()
 
   Object.entries(params).forEach(([key, value]) => {
     if (value !== undefined && value !== null && String(value).trim() !== '') {
-      queryParams.append(key, value);
+      queryParams.append(key, value)
     }
-  });
+  })
 
-  const queryString = queryParams.toString();
-  const url = `${API_BASE}asset-mappings/re-map/preview${queryString ? `?${queryString}` : ''}`;
+  const queryString = queryParams.toString()
+  const url = `${API_BASE}asset-mappings/re-map/preview${queryString ? `?${queryString}` : ''}`
 
   const response = await fetch(url, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
     },
-  });
+  })
 
-  const data = await response.json();
+  const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage = data.detail || data.error || data.message || `HTTP error! status: ${response.status}`;
-    throw new Error(errorMessage);
+    const errorMessage =
+      data.detail || data.error || data.message || `HTTP error! status: ${response.status}`
+    throw new Error(errorMessage)
   }
 
-  return data;
-};
+  return data
+}
 
 /**
  * Re-maps asset mappings by deleting existing mappings and regenerating them.
@@ -928,14 +936,15 @@ export const remapAssetMappings = async (params = {}) => {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(params),
-  });
+  })
 
-  const data = await response.json();
+  const data = await response.json()
 
   if (!response.ok) {
-    const errorMessage = data.detail || data.error || data.message || `HTTP error! status: ${response.status}`;
-    throw new Error(errorMessage);
+    const errorMessage =
+      data.detail || data.error || data.message || `HTTP error! status: ${response.status}`
+    throw new Error(errorMessage)
   }
 
-  return data;
-};
+  return data
+}


### PR DESCRIPTION
## Summary

Closes #68
Closes #76 

This PR implements the **Asset Re-mapping** feature, allowing users to delete and regenerate asset mappings based on configurable filters. The primary use case is updating crypto mappings after changing a provider's preferred quote currency setting (e.g., switching from USD to USDT pairs).

### Key Capabilities

- **Re-map after quote currency change**: When users change a crypto provider's preferred quote currency in ProviderConfigModal, they're prompted to re-map crypto assets to reflect the new preference
- **Filter-based re-mapping from Mappings page**: Users can filter by provider and/or asset class, then trigger a targeted re-map operation on the filtered results
- **Impact preview**: Before confirming, users see how many mappings will be deleted and which user-defined indices may be affected
- **Atomic operations**: Re-map either completes fully or rolls back completely on any error (REPEATABLE READ isolation)

### User Stories Implemented

| Story | Priority | Description |
|-------|----------|-------------|
| US1 | P1 | Re-map crypto after quote currency change |
| US2 | P2 | Re-map filtered assets from Mappings page |
| US3 | P2 | View impact before re-mapping |
| US4 | P3 | Atomic re-map operation with rollback |

## API Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/registry/asset-mappings/re-map/preview` | Preview re-map impact (mapping count, affected indices) |
| POST | `/api/registry/asset-mappings/re-map` | Execute atomic re-map operation |

## Changes

### Backend (`quasar/services/registry/`)
- **schemas.py**: Added `AssetMappingRemapRequest`, `AssetMappingRemapPreview`, `AssetMappingRemapResponse` Pydantic models
- **handlers/mappings.py**: Added `handle_remap_preview()`, `handle_remap_assets()` handlers with helper methods for filter query building and affected indices detection
- **core.py**: Registered new routes; fixed route ordering bug for common-symbols endpoint (#76)

### Frontend (`web/src/views/`)
- **mappings/RemapConfirmModal.js**: New modal showing preview, confirmation, and completion summary with theme-aware styling
- **mappings/Mappings.js**: Added asset class and provider filter dropdowns, "Re-map Filtered" button in visual filter box
- **registry/RemapPromptModal.js**: New Yes/No prompt shown after changing crypto quote currency preference
- **registry/ProviderConfigModal.js**: Integrated re-map prompt flow after saving preference changes
- **services/registry_api.js**: Added `getRemapPreview()` and `remapAssetMappings()` API client functions

### Code Quality Improvements
- Extracted duplicate `getClassBadge()` and `getActiveBadge()` helpers to `web/src/utils/badgeHelpers.js`
- Fixed transaction boundary issue in `_apply_automated_mappings()` to ensure atomicity
- Used `formatErrorMessage()` consistently for API error handling
- Wrapped `fetchMappings` in `useCallback` to fix React hooks dependency warning
- Fixed dark theme text color compliance in confirmation messages

### Bug Fixes
- **#76**: Fixed route ordering bug where `/api/registry/asset-mappings/{common_symbol}` was capturing `/api/registry/asset-mappings/common-symbols` requests

## Test Plan

- [x] Backend tests pass: `pytest tests/services/registry/test_handlers_mappings.py` (216 passed)
- [x] Frontend builds: `npm run build`
- [x] Manual testing:
  - [x] Change crypto provider quote preference → re-map prompt appears → mappings updated
  - [x] Filter mappings on Mappings page → click Re-map Filtered → preview shows correct counts → confirm → mappings regenerated
  - [x] Verify affected indices warning displays when applicable
  - [x] Verify error handling and retry functionality
  - [x] Verify light/dark theme compliance

## Screenshots

The re-map confirmation modal shows:
- Filter summary and mapping count to be deleted
- Affected providers list
- Warning for affected indices with cascade impact explanation
- Completion summary with deleted/created/skipped counts

## Specification

Full feature specification available in `/specs/001-asset-remap/`:
- `spec.md` - User stories and requirements
- `plan.md` - Implementation plan
- `tasks.md` - 46 implementation tasks (all completed)
- `contracts/remap-api.yaml` - OpenAPI contract